### PR TITLE
Feat/oauth/users management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.0">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.0-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.5">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.5-7c3aed">
   </a>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notehub",
-  "version": "0.1.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(pages)/changelog/elements/GoBack.tsx
+++ b/src/app/(pages)/changelog/elements/GoBack.tsx
@@ -1,0 +1,19 @@
+import { IconArrowLeft } from "@tabler/icons-react";
+import Link, { LinkProps } from "next/link";
+
+export const GoBack = (props: Omit<LinkProps, 'href'>) => (
+    <Link
+        href={'/'}
+        className="group select-none relative w-fit flex items-center gap-3"
+        {...props}
+    >
+        <span
+            className="group-hover:-translate-x-2 transition-transform duration-300"
+        >
+            <IconArrowLeft size={18} strokeWidth={3} className="dark:text-lighter text-darker" />
+        </span>
+        <span className="font-semibold dark:text-lighter text-darker">
+            Voltar
+        </span>
+    </Link>
+)

--- a/src/app/(pages)/changelog/elements/Header.tsx
+++ b/src/app/(pages)/changelog/elements/Header.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { clsx } from "clsx";
+import { GoBack } from "./GoBack";
+import { Title } from "./Title";
+import { usePref } from "@/data/hooks";
+
+export const Header = (props: React.HTMLAttributes<HTMLElement>) => {
+
+    const { pref: { useDarkTheme } } = usePref();
+
+    return (
+        <header
+            className={clsx(useDarkTheme ? 'dark-changelog-header' : 'light-changelog-header')}
+            {...props}
+        >
+            <div
+                className="max-w-[666px] w-full mx-auto py-12 border-b dark:border-semidark border-semilight flex flex-col gap-6"
+            >
+                <GoBack />
+                <Title>Changelog</Title>
+            </div>
+        </header>
+    )
+
+}

--- a/src/app/(pages)/changelog/elements/Release.tsx
+++ b/src/app/(pages)/changelog/elements/Release.tsx
@@ -1,0 +1,6 @@
+export const Release = (props: React.HTMLAttributes<HTMLElement>) => (
+    <section
+        className="flex flex-col gap-9"
+        {...props}
+    />
+)

--- a/src/app/(pages)/changelog/elements/ReleaseDesc.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseDesc.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+interface ReleaseDescProps extends React.HTMLAttributes<HTMLParagraphElement> {
+    pr: number;
+    hash: string;
+}
+
+export const ReleaseDesc = ({ pr, hash, children, ...rest }: ReleaseDescProps) => (
+    <li>
+        <p
+            className="font-semibold text-sm dark:text-lighter text-darker"
+            {...rest}
+        >
+            <Link
+                className="mr-1 dark:text-secondary text-primary"
+                href={`https://github.com/NoteHubBR/notehub-api/pull/${pr}/commits/${hash}`}
+            >
+                [#{hash.substring(0, 7)}]
+            </Link>
+            {children}
+        </p>
+    </li>
+)

--- a/src/app/(pages)/changelog/elements/ReleaseOList.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseOList.tsx
@@ -1,0 +1,6 @@
+export const ReleaseOList = (props: React.OlHTMLAttributes<HTMLOListElement>) => (
+    <ol
+        className="ml-14 list-disc"
+        {...props}
+    />
+)

--- a/src/app/(pages)/changelog/elements/ReleaseTitle.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseTitle.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+interface ReleaseTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+    tag: string;
+}
+
+export const ReleaseTitle = ({ tag, children, ...rest }: ReleaseTitleProps) => (
+    <h2 className="font-semibold text-2xl dark:text-lighter text-darker" {...rest}>
+        <Link
+            href={`https://github.com/NoteHubBR/notehub-api/releases/tag/${tag}`}
+            className="underline w-fit"
+        >
+            {tag.replace('v', '')}
+        </Link>
+        <span className="ml-3">{children}</span>
+    </h2>
+)

--- a/src/app/(pages)/changelog/elements/ReleaseTopic.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseTopic.tsx
@@ -1,0 +1,88 @@
+import { IconBoltFilled, IconBookFilled, IconFileTypeCss, IconFlaskFilled, IconLockFilled, IconPackage, IconRecycle, IconSparkles } from "@tabler/icons-react";
+import { ReleaseEntryType } from "@/shared";
+
+interface TopicProps extends React.HTMLAttributes<HTMLHeadingElement> {
+    icon: React.ElementType;
+}
+
+const Topic = ({ icon: Icon, children, ...rest }: TopicProps) => (
+    <h3 className="flex items-center gap-3" {...rest}>
+        <span className="p-1 rounded-full dark:bg-secondary bg-primary">
+            <Icon size={22} className="text-lighter" />
+        </span>
+        <span className="font-semibold text-xl dark:text-lighter text-darker">
+            {children}
+        </span>
+    </h3>
+)
+
+interface ReleaseTopicProps extends React.LiHTMLAttributes<HTMLLIElement> {
+    type: ReleaseEntryType
+}
+
+export const ReleaseTopic = ({ type, children, ...rest }: ReleaseTopicProps) => {
+
+    if (type === 'sec') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconLockFilled}>Segurança</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'feat') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconSparkles}>Implementação</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'fix') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconSparkles}>Correção</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'docs') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconBookFilled}>Documentação</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'style') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconFileTypeCss}>Estilização</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'refactor') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconRecycle}>Refatoração</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'perf') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconBoltFilled}>Performance</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'test') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconFlaskFilled}>Teste</Topic>
+            {children}
+        </li>
+    )
+
+    if (type === 'chore') return (
+        <li className="flex flex-col gap-3" {...rest}>
+            <Topic icon={IconPackage}>Manutenção</Topic>
+            {children}
+        </li>
+    )
+
+}

--- a/src/app/(pages)/changelog/elements/ReleaseUList.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseUList.tsx
@@ -1,0 +1,6 @@
+export const ReleaseUList = (props: React.HTMLAttributes<HTMLUListElement>) => (
+    <ul
+        className="pl-6 border-l-2 dark:border-secondary border-primary flex flex-col gap-6"
+        {...props}
+    />
+)

--- a/src/app/(pages)/changelog/elements/Title.tsx
+++ b/src/app/(pages)/changelog/elements/Title.tsx
@@ -1,0 +1,6 @@
+export const Title = (props: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h1
+        className="font-bold text-5xl dark:text-lighter text-darker"
+        {...props}
+    />
+)

--- a/src/app/(pages)/changelog/elements/index.ts
+++ b/src/app/(pages)/changelog/elements/index.ts
@@ -1,0 +1,9 @@
+export { GoBack } from './GoBack';
+export { Header } from './Header';
+export { Title } from './Title';
+export { Release } from './Release';
+export { ReleaseTitle } from './ReleaseTitle';
+export { ReleaseUList } from './ReleaseUList';
+export { ReleaseTopic } from './ReleaseTopic';
+export { ReleaseOList } from './ReleaseOList';
+export { ReleaseDesc } from './ReleaseDesc';

--- a/src/app/(pages)/changelog/page.tsx
+++ b/src/app/(pages)/changelog/page.tsx
@@ -1,0 +1,49 @@
+import { Header, Release, ReleaseDesc, ReleaseOList, ReleaseTitle, ReleaseTopic, ReleaseUList } from "./elements";
+import { ReleaseEntryType, releases } from "@/shared";
+
+type ReleasesArray = typeof releases;
+type ReleaseType = ReleasesArray[number];
+type Entry = ReleaseType["entries"][number];
+
+const Page = () => {
+
+    const groupByType = (entries: Entry[]): Partial<Record<ReleaseEntryType, Entry[]>> =>
+        entries.reduce<Partial<Record<ReleaseEntryType, Entry[]>>>((acc, e) => {
+            const t = e.type as ReleaseEntryType;
+            if (!acc[t]) acc[t] = [];
+            acc[t]!.push(e);
+            return acc;
+        }, {})
+
+    return (
+        <main className="max-w-full w-screen insm:px-3 flex flex-col gap-12">
+            <Header />
+            <div className="max-w-[666px] w-full mx-auto flex flex-col gap-12">
+                {releases.map((release: ReleaseType) => {
+                    const grouped = groupByType(release.entries);
+                    return (
+                        <Release key={release.version}>
+                            <ReleaseTitle tag={release.version}>({release.title})</ReleaseTitle>
+                            <ReleaseUList>
+                                {(Object.entries(grouped) as [ReleaseEntryType, Entry[]][]).map(([type, entries]) => (
+                                    <ReleaseTopic key={type} type={type}>
+                                        <ReleaseOList>
+                                            {entries.map((entry: Entry, idx: number) => (
+                                                <ReleaseDesc key={entry.hash ?? idx} pr={entry.pr} hash={entry.hash}>
+                                                    {entry.desc}
+                                                </ReleaseDesc>
+                                            ))}
+                                        </ReleaseOList>
+                                    </ReleaseTopic>
+                                ))}
+                            </ReleaseUList>
+                        </Release>
+                    )
+                })}
+            </div>
+        </main>
+    )
+
+}
+
+export default Page;

--- a/src/app/(pages)/dashboard/user/aside/changelog/elements/Change.tsx
+++ b/src/app/(pages)/dashboard/user/aside/changelog/elements/Change.tsx
@@ -1,7 +1,27 @@
 import Link, { LinkProps } from "next/link";
 
-export const Change = ({ children, ...rest }: { children: React.ReactNode } & LinkProps) => (
-    <Link target="_blank" className="font-medium text-sm hover:underline hover:text-secondary" {...rest} >
-        {children}
-    </Link>
-)
+interface ChangeProps extends Omit<LinkProps, 'href'> {
+    toId: string;
+    children: React.ReactNode;
+}
+
+export const Change = ({ toId, children, ...rest }: ChangeProps) => {
+
+    const handleClick = (): void => {
+        const element = document.getElementById(toId);
+        if (element) return element.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+    }
+
+    return (
+        <Link
+            href='/changelog'
+            onClick={handleClick}
+            className="font-medium text-sm hover:underline hover:text-secondary"
+            {...rest}
+        >
+            {children}
+        </Link>
+    )
+
+}

--- a/src/app/(pages)/dashboard/user/aside/changelog/index.tsx
+++ b/src/app/(pages)/dashboard/user/aside/changelog/index.tsx
@@ -1,33 +1,30 @@
-import { IconGitCommit } from "@tabler/icons-react";
+import { Element } from "./elements";
+import { releases } from "@/shared";
 
 export const Changelog = () => {
 
+    const { Title, Li, Time, Change, Link } = Element;
+
     return (
         <section
-            className="w-full min-h-[222px] p-3 rounded-[5px]
-            flex items-center justify-center
+            className="w-full h-fit p-3 rounded-[5px]
             dark:bg-darker bg-lighter
             dark:drop-shadow-alpha-l-sm drop-shadow-alpha-d-sm
-            inlg:h-full"
+            inlg:h-full
+            inmd:w-full"
         >
-            <div
-                role="dialog"
-                aria-labelledby="dialogTitle"
-                aria-describedby="dialogDesc"
-                className="flex flex-1 items-center justify-center gap-3"
-            >
-                <figure className="w-fit p-2 border-2 dark:border-neutral-500/75 border-neutral-400/75 rounded-full">
-                    <IconGitCommit size={33} className="dark:text-neutral-500/75 text-neutral-400/75" />
-                </figure>
-                <section>
-                    <h2 id="dialogTitle" className="text-lg dark:text-lighter/75 text-darker/75">
-                        Changelog
-                    </h2>
-                    <p id="dialogDesc" className="text-sm dark:text-lighter/50 text-darker/50">
-                        Em andamento...
-                    </p>
-                </section>
-            </div>
+            <header>
+                <Title>Últimas alterações</Title>
+            </header>
+            <ul className="p-3">
+                {releases.slice(0, 4).map((release, key) => (
+                    <Li key={key}>
+                        <Time time={release.date} />
+                        <Change toId={release.version}>{release.summary}</Change>
+                    </Li>
+                ))}
+                <Li><Link /></Li>
+            </ul>
         </section>
     )
 

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/OAuthUserTitle.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/OAuthUserTitle.tsx
@@ -1,0 +1,61 @@
+import { clsx } from "clsx";
+import { IconSend } from "@tabler/icons-react";
+import { useServices, useUser } from "@/data/hooks";
+import { useState } from "react";
+
+export const OAuthUserTitle = (props: React.HTMLAttributes<HTMLElement>) => {
+
+    const { authService: { sendSecretKeyRequest } } = useServices();
+    const { user } = useUser();
+
+    const [isPending, setIsPending] = useState<boolean>(false);
+    const [sent, setSent] = useState<boolean>(false);
+
+    const handleClick = async () => {
+        if (user) {
+            setIsPending(true);
+            return await sendSecretKeyRequest({ email: user.email })
+                .then(() => {
+                    setIsPending(false);
+                    setSent(true);
+                })
+        }
+    }
+
+    return (
+        <header className="flex flex-col gap-y-3 pb-3" {...props}>
+            <p className={clsx(
+                'relative origin-bottom-right',
+                sent ? 'visible scale-100 h-auto mt-6' : 'invisible scale-0 h-0 nt-0',
+                'p-2 rounded-lg',
+                'border-l-8 dark:border-middark border-midlight',
+                'text-sm dark:text-midlight text-middark',
+                'dark:bg-middark/50 bg-midlight/50',
+                'transition-all duration-300')}
+            >
+                Chave enviada via email
+            </p>
+            <div className="relative px-2 py-3 flex items-center justify-between">
+                <h3>Não tem chave?</h3>
+                <button
+                    disabled={sent || isPending}
+                    onClick={handleClick}
+                    className={clsx(
+                        'select-none',
+                        'absolute top-1/2 -translate-y-1/2 right-2',
+                        'px-4 py-2 rounded-full',
+                        'text-sm text-white',
+                        'dark:bg-midlight/50 bg-middark/50',
+                        'hover:!bg-primary',
+                        'active:top-[calc(50%+3px)]',
+                        'disabled:cursor-not-allowed disabled:active:top-1/2 disabled:!bg-primary/50',
+                        'transition-all'
+                    )}
+                >
+                    <IconSend className="inline-block align-top" size={20} /> Solicitar
+                </button>
+            </div>
+        </header>
+    )
+
+}

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/UserTitle.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/UserTitle.tsx
@@ -1,0 +1,5 @@
+export const UserTitle = (props: React.HTMLAttributes<HTMLElement>) => (
+    <header className="mt-6 px-2 py-3" {...props}>
+        <h3>Confirme sua autoridade</h3>
+    </header>
+)

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/index.ts
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/index.ts
@@ -1,4 +1,6 @@
-import { Card } from "./Card";
+import { UserTitle } from "./UserTitle";
+import { OAuthUserTitle } from "./OAuthUserTitle";
 import { Warnings } from "./Warnings";
+import { Card } from "./Card";
 
-export const Element = { Warnings, Card };
+export const Element = { UserTitle, OAuthUserTitle, Warnings, Card };

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/page.tsx
@@ -3,16 +3,19 @@
 import { Element } from "./elements";
 import { Form } from "@/components/forms";
 import { Header } from "../../../Header";
+import { useUser } from "@/data/hooks";
 
 const Page = () => {
 
-    const { Warnings, Card } = Element;
+    const { user } = useUser();
 
-    return (
+    const { UserTitle, OAuthUserTitle, Warnings, Card } = Element;
+
+    if (user) return (
         <section>
             <Header goBack="/settings/account" title="Deletar conta" />
-            <section className="mt-6 flex flex-col gap-3">
-                <h3 className="px-2 py-3">Confirme sua autoridade</h3>
+            <section className="flex flex-col gap-3">
+                {user.host === 'NoteHub' ? <UserTitle /> : <OAuthUserTitle></OAuthUserTitle>}
                 <Form.User.Delete />
                 <Warnings />
                 <Card />

--- a/src/app/(pages)/settings/(pages)/account/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/page.tsx
@@ -17,9 +17,9 @@ const Page = () => {
                 <ul className="mt-6">
                     <Link href={"/settings/account/info"} icon={IconUser}>Informações</Link>
                     <Link href={"/settings/account/visibility"} icon={IconEye}>Alterar visibilidade</Link>
+                    <Link href={"/settings/account/email"} icon={IconMail}>Alterar email</Link>
                     {user.host === "NoteHub" &&
                         <>
-                            <Link href={"/settings/account/email"} icon={IconMail}>Alterar email</Link>
                             <Link href={"/settings/account/password"} icon={IconKey}>Alterar senha</Link>
                         </>
                     }

--- a/src/components/forms/auth/signin/elements/OAuthError.tsx
+++ b/src/components/forms/auth/signin/elements/OAuthError.tsx
@@ -1,0 +1,17 @@
+interface oAuthErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {
+    error: string | undefined;
+}
+
+const OAuthError = ({ error, ...rest }: oAuthErrorProps) => {
+    if (error) return (
+        <p
+            className="px-1 font-bold text-center text-sm dark:text-red-500 text-rose-500"
+            {...rest}
+        >
+            {error}
+        </p>
+    )
+    return null;
+}
+
+export default OAuthError;

--- a/src/components/forms/auth/signin/elements/index.tsx
+++ b/src/components/forms/auth/signin/elements/index.tsx
@@ -7,5 +7,6 @@ import Button from "./Button";
 import Link from "./Link";
 import Separator from "./Separator";
 import OAuthButton from "./OAuthButton";
+import OAuthError from "./OAuthError";
 
-export const Element = { Header, Field, Label, Input, Error, Button, Link, Separator, OAuthButton };
+export const Element = { Header, Field, Label, Input, Error, Button, Link, Separator, OAuthButton, OAuthError };

--- a/src/components/forms/user/delete/elements/Input.tsx
+++ b/src/components/forms/user/delete/elements/Input.tsx
@@ -15,7 +15,6 @@ export const Input = ({ name, ...rest }: InputProps) => {
             id={name}
             {...register(name)}
             type="password"
-            placeholder="Digite sua senha"
             autoComplete="off"
             autoCorrect="off"
             spellCheck={false}

--- a/src/components/forms/user/delete/index.tsx
+++ b/src/components/forms/user/delete/index.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 export const Form = () => {
 
     const { userService: { deleteUser } } = useServices();
-    const { token, clearUser } = useUser();
+    const { token, user, clearUser } = useUser();
 
     const deleteUserForm = useForm<DeleteUserFormData>({
         resolver: zodResolver(deleteUserFormSchema)
@@ -36,12 +36,12 @@ export const Form = () => {
 
     const { Wrapper, Label, Input, Button, Error } = Element;
 
-    return (
+    if (user) return (
         <FormProvider {...deleteUserForm}>
             <form onSubmit={handleSubmit(onSubmit)} className="px-2 flex flex-col gap-1">
                 <Wrapper>
                     <Label name="password" />
-                    <Input name="password" />
+                    <Input name="password" placeholder={user.host === 'NoteHub' ? 'Digite sua senha' : 'Digite sua chave'} />
                     <Button disabled={isPending}>
                         Excluir
                     </Button>

--- a/src/core/utils/FieldError.ts
+++ b/src/core/utils/FieldError.ts
@@ -29,3 +29,18 @@ export function handleFieldErrorsMsg(errors: FieldError[]): { notMutual: boolean
     }
     return { notMutual: false, notCurrent: false };
 }
+
+export function handleOAuthError(
+    errors: FieldError[],
+    setError: React.Dispatch<React.SetStateAction<{
+        isRequesting: boolean;
+        isGoogleAuthInProgress: boolean;
+        isGitHubAuthInProgress: boolean;
+        oAuthError: string | undefined;
+    }>>
+): void {
+    for (const error of errors) {
+        return setError((prev) => ({ ...prev, oAuthError: error.message }));
+    }
+    return;
+}

--- a/src/core/utils/Routes.ts
+++ b/src/core/utils/Routes.ts
@@ -23,7 +23,8 @@ export enum Routes {
     CHANGE_EMAIL = '/change/email',
     CHANGE_PASSWORD = '/change/password',
     NEW = '/new',
-    HELP = '/help'
+    HELP = '/help',
+    CHANGELOG = '/changelog'
 }
 
 enum NotUserContextRoutes {
@@ -33,7 +34,8 @@ enum NotUserContextRoutes {
     ACTIVATE = '/activate/:jwt',
     CHANGE_EMAIL = '/change/email',
     CHANGE_PASSWORD = '/change/password',
-    HELP = '/help'
+    HELP = '/help',
+    CHANGELOG = '/changelog'
 }
 
 export const shouldUseUserContext = (pathname: string): boolean => {

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -58,6 +58,14 @@ export const AuthService = () => {
         }
     }
 
+    const sendSecretKeyRequest = useCallback(async (email: { email: string }): Promise<void> => {
+        try {
+            return await httpPost('/auth/secret-key', email, { useProgress: true });
+        } catch (error) {
+            throw error;
+        }
+    }, [httpPost])
+
     const sendEmailChangeRequest = useCallback(async (email: { email: string }): Promise<void> => {
         try {
             return await httpPost('/auth/change-email', email, { useProgress: true });
@@ -81,6 +89,7 @@ export const AuthService = () => {
         refreshUser,
         handleExpiredToken,
         logoutUser,
+        sendSecretKeyRequest,
         sendEmailChangeRequest,
         sendPasswordChangeRequest
     }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './releases';

--- a/src/shared/releases/index.ts
+++ b/src/shared/releases/index.ts
@@ -1,0 +1,1 @@
+export * from './releases';

--- a/src/shared/releases/releases.ts
+++ b/src/shared/releases/releases.ts
@@ -1,0 +1,39 @@
+export type ReleaseEntryType = 'sec' | 'feat' | 'fix' | 'docs' | 'style' | 'refactor' | 'perf' | 'test' | 'chore';
+
+export interface ReleaseEntry {
+    type: ReleaseEntryType;
+    pr: number;
+    hash: string;
+    desc: string;
+}
+
+export interface Release {
+    version: string;
+    date: string;
+    title: string;
+    summary: string;
+    entries: ReleaseEntry[];
+}
+
+export const releases: Release[] = [
+    {
+        version: 'v1.5',
+        date: '17/09/25 12:34',
+        title: 'Setembro 17, 2025',
+        summary: 'Melhorias para usuários vindos de aplicações externas.',
+        entries: [
+            {
+                type: 'sec',
+                pr: 2,
+                hash: '11ce75c0f4d3cc93519daf73da4a487e48a38f0c',
+                desc: 'Usuários vindos de aplicações externas podem trocar o email vinculado a conta.'
+            },
+            {
+                type: 'feat',
+                pr: 2,
+                hash: '8245608e75dfcbe31b9b1a6f1203f3a0eb1a0985',
+                desc: 'Liberada a exclusão de conta para usuários vindos de aplicações externas.'
+            }
+        ]
+    }
+]

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -28,6 +28,14 @@
     @include mixins.vignette-checkered(#fafafa, #0a0a0a);
 }
 
+.dark-changelog-header {
+    @include mixins.changelog-checkered-header(white, black);
+}
+
+.light-changelog-header {
+    @include mixins.changelog-checkered-header(black, white);
+}
+
 .light-vignette-checkered {
     @include mixins.vignette-checkered(#0a0a0a, #fafafa);
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -134,6 +134,32 @@
     }
 }
 
+@mixin changelog-checkered-header($stripeColor, $gradientSideColor) {
+    position: relative;
+
+    &::before {
+        content: '';
+        z-index: -2;
+        position: absolute;
+        inset: 0;
+        top: 0;
+        left: 0;
+        background-image: linear-gradient(to right, $stripeColor 1px, transparent 1px), linear-gradient(to bottom, $stripeColor 1px, transparent 1px);
+        background-size: 40px 40px;
+        opacity: .1;
+    }
+
+    &::after {
+        content: '';
+        z-index: -1;
+        position: absolute;
+        inset: 0;
+        top: 0;
+        left: 0;
+        background: linear-gradient(to top, $gradientSideColor 0%, transparent 50%);
+    }
+}
+
 @mixin applying {
     z-index: 1;
     overflow: hidden;


### PR DESCRIPTION
### Sumário
O PR introduz melhorias significantes para usuários vindo de aplicativos externos com autorizações abertas(OAuth).

### Alterações
- `README.md` preparado para aceitar a release 1.5;
- Em caso de erro no login via aplicativos externos o motivo é devidamente disponibilizado ao usuário;
- Usuários OAuth podem requisitar troca de email;
- Permitido exclusão de usuários OAuth usando chave secreta enviada via email;
- Adicionada rota /changelog para detalhar todas as atualizações;
- Adicionado cartão lateral na rota principal com as quatro últimas atualizações;

### Necessidade
- Não há um universo onde usuários externos não possam excluir suas contas e alterar o email registrado;
- Um aplicativo open-source deve disponibilizar as alterações realizadas em cada release de maneira prática para que todos possam entender e visualizar;

### Teste manual
- Crie e configure um OAuth App no GitHub;
- Adapte a API;
- Inicie a aplicação com as devidas variáveis de ambiente;
- Crie uma conta com o email utilizado na conta do GitHub;
- Tente logar via GitHub e verá o erro;
- Requisite troca de email;
- Requisite chave secreta para exclusão;
- Visite a rota /changelog;

 ### Checklist
 
- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados