### PR TITLE
feat(user): block image updates for blocked users and support null banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.5">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.5-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.6">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.6-7c3aed">
   </a>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notehub",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(pages)/[username]/components/desktop/layout/Banner.tsx
+++ b/src/app/(pages)/[username]/components/desktop/layout/Banner.tsx
@@ -18,11 +18,10 @@ export const Banner = ({ user, history }: { user: User | LowDetailUser, history:
                 ref={bannerRef}
                 user={user}
                 className={clsx(
-                    'cursor-pointer overlay',
-                    user.banner ?? '!cursor-default !overlay-none'
+                    user.blocked || !user.banner ? 'cursor-default' : 'cursor-pointer overlay'
                 )}
             />
-            {user.banner &&
+            {!user.blocked && user.banner &&
                 <Template.Portal triggerRef={bannerRef} childRef={upscaledBannerRef} useDefaultClose>
                     <Component.PicturePortal ref={upscaledBannerRef} user={user} fill />
                 </Template.Portal>
@@ -31,13 +30,12 @@ export const Banner = ({ user, history }: { user: User | LowDetailUser, history:
                 ref={photoRef}
                 user={user} size={111}
                 className={clsx(
-                    'cursor-pointer overlay',
                     'absolute bottom-0 left-4 inlg:left-2 translate-y-1/2',
                     'border-4 dark:border-darker border-lighter',
-                    user.avatar ?? '!cursor-default !overlay-none'
+                    user.blocked || !user.avatar ? 'cursor-default' : 'cursor-pointer overlay'
                 )}
             />
-            {user.avatar &&
+            {!user.blocked && user.avatar &&
                 <Template.Portal triggerRef={photoRef} childRef={upscaledPhotoRef} useDefaultClose>
                     <Component.PicturePortal ref={upscaledPhotoRef} user={user} size={369} className="rounded-full" />
                 </Template.Portal>

--- a/src/app/(pages)/[username]/components/mobile/Header.tsx
+++ b/src/app/(pages)/[username]/components/mobile/Header.tsx
@@ -26,16 +26,18 @@ export const Header = ({ user, ...rest }: { user: User | LowDetailUser } & React
 
     return (
         <header
-            style={{ backgroundImage: `url('${user.banner ?? '/imgs/banner.png'}')` }}
+            style={{ backgroundImage: `url('${user.blocked ? 'imgs/banner.png' : user.banner ?? 'imgs/banner.png'}')` }}
             className="relative py-5 bg-cover bg-no-repeat bg-center"
             {...rest}
         >
             <div className="pointer-events-none absolute inset-0 dark:bg-d-gradient bg-l-gradient" />
             <section className="relative z-10 flex flex-col items-center gap-3 ">
                 <Component.Photo ref={photoRef} user={user} size={111} className="cursor-pointer drop-shadow-alpha-d-sm" />
-                <Template.Portal triggerRef={photoRef} childRef={upscaledPhotoRef} useDefaultClose>
-                    <Component.PicturePortal ref={upscaledPhotoRef} user={user} size={270} className="rounded-full" />
-                </Template.Portal>
+                {!user.blocked && user.avatar &&
+                    <Template.Portal triggerRef={photoRef} childRef={upscaledPhotoRef} useDefaultClose>
+                        <Component.PicturePortal ref={upscaledPhotoRef} user={user} size={270} className="rounded-full" />
+                    </Template.Portal>
+                }
                 <div className="w-full px-3 overflow-hidden flex items-center justify-center gap-3">
                     <Layout.Title>
                         <Icon.Sponsor user={user} size={25} />

--- a/src/app/(pages)/changelog/elements/ReleaseOList.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseOList.tsx
@@ -1,6 +1,6 @@
 export const ReleaseOList = (props: React.OlHTMLAttributes<HTMLOListElement>) => (
     <ol
-        className="ml-14 list-disc"
+        className="ml-14 list-disc flex flex-col gap-3"
         {...props}
     />
 )

--- a/src/app/(pages)/help/items.tsx
+++ b/src/app/(pages)/help/items.tsx
@@ -177,6 +177,21 @@ export const items: Items[] = [
         useSupport: true
     },
     {
+        id: 'blocked',
+        keywords: ["blocked", "block", "bloqueio", "bloqueado", "proibido", "excluido", "apagado", "cancelado", "silenciado", "suporte"],
+        hash: '#blocked',
+        question: 'Bloqueio',
+        answer: (
+            <>
+                Um usuário bloqueado não pode atualizar fotos do perfil, o bloqueio é devido à conteúdo impróprio.
+                <br /><br />
+                Caso discorde de um bloqueio, entre em contato com o suporte ao usuário para contestação.
+                <br /><br />
+            </>
+        ),
+        useSupport: true
+    },
+    {
         id: 'ban',
         keywords: ["ban", "banir", "banido", "banimento", "excluído", "excluido", "apagado", "cancelado", "silenciado", "suporte"],
         hash: '#ban',

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -19,7 +19,7 @@ export const Banner = forwardRef<HTMLImageElement, BannerProps>((props, ref) => 
         >
             <Image
                 priority
-                src={src ?? user?.banner ?? '/imgs/banner.png'}
+                src={src ? src : user && user.banner ? user.blocked ? '/imgs/banner.png' : user.banner : '/imgs/banner.png'}
                 fill
                 alt={`Avatar de ${user?.username ?? 'ex usuário'}`}
             />

--- a/src/components/Photo.tsx
+++ b/src/components/Photo.tsx
@@ -18,7 +18,7 @@ export const Photo = forwardRef<HTMLImageElement, PhotoProps>((props, ref) => {
             className={`select-none overflow-hidden flex-none rounded-full ${className}`} {...rest}
         >
             <Image
-                src={src ?? user?.avatar ?? '/imgs/avatar.png'}
+                src={src ? src : user && user.avatar ? user.blocked ? '/imgs/avatar.png' : user.avatar : '/imgs/avatar.png'}
                 width={size}
                 height={size}
                 alt={`Avatar de ${user?.username ?? 'ex usuário'}`}

--- a/src/components/forms/user/update/elements/Avatar.tsx
+++ b/src/components/forms/user/update/elements/Avatar.tsx
@@ -55,7 +55,13 @@ export const Avatar = ({ user, onModalOpen, onModalClose, ...props }: AvatarProp
                     src={url} user={user} size={onDesktop ? 111 : 88}
                     className="border-4 dark:border-darker border-lighter" {...props}
                 />
-                <Upload ref={triggerRef} name="avatar" handleFileChange={handleFileChange} isBlocked={user.blocked} />
+                <Upload
+                    ref={triggerRef}
+                    name="avatar"
+                    handleFileChange={handleFileChange}
+                    isBlocked={user.blocked}
+                    className="center"
+                />
             </div>
             <Template.Modal
                 triggerRef={triggerRef}

--- a/src/components/forms/user/update/elements/Avatar.tsx
+++ b/src/components/forms/user/update/elements/Avatar.tsx
@@ -55,7 +55,7 @@ export const Avatar = ({ user, onModalOpen, onModalClose, ...props }: AvatarProp
                     src={url} user={user} size={onDesktop ? 111 : 88}
                     className="border-4 dark:border-darker border-lighter" {...props}
                 />
-                <Upload ref={triggerRef} name="avatar" handleFileChange={handleFileChange} />
+                <Upload ref={triggerRef} name="avatar" handleFileChange={handleFileChange} isBlocked={user.blocked} />
             </div>
             <Template.Modal
                 triggerRef={triggerRef}

--- a/src/components/forms/user/update/elements/Banner.tsx
+++ b/src/components/forms/user/update/elements/Banner.tsx
@@ -2,6 +2,7 @@ import { Component, CropperRef } from "@/components";
 import { EditUserFormData, User } from "@/core";
 import { Header } from "./Header";
 import { IconArrowLeft } from "@tabler/icons-react";
+import { Removal } from "./Removal";
 import { Template } from "@/components/templates";
 import { Upload } from "./Upload";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -45,11 +46,30 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
         }
     }, [setValue])
 
+    const handleRemovalClick = (): void => {
+        setUrl('/imgs/banner.png');
+        setValue('banner', null);
+        return;
+    }
+
     return (
         <>
             <div className="select-none relative" {...rest}>
                 <Component.Banner src={url} user={user} />
-                <Upload ref={triggerRef} name="banner" handleFileChange={handleFileChange} isBlocked={user.blocked} />
+                <div className="center flex items-center gap-3">
+                    <Upload
+                        ref={triggerRef}
+                        name="banner"
+                        handleFileChange={handleFileChange}
+                        isBlocked={user.blocked}
+                    />
+                    <Removal
+                        name="removal"
+                        handleRemovalClick={handleRemovalClick}
+                        isBlocked={user.blocked}
+                        currentImg={url}
+                    />
+                </div>
                 {rest.children}
             </div>
             <Template.Modal

--- a/src/components/forms/user/update/elements/Banner.tsx
+++ b/src/components/forms/user/update/elements/Banner.tsx
@@ -49,7 +49,7 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
         <>
             <div className="select-none relative" {...rest}>
                 <Component.Banner src={url} user={user} />
-                <Upload ref={triggerRef} name="banner" handleFileChange={handleFileChange} />
+                <Upload ref={triggerRef} name="banner" handleFileChange={handleFileChange} isBlocked={user.blocked} />
                 {rest.children}
             </div>
             <Template.Modal

--- a/src/components/forms/user/update/elements/Removal.tsx
+++ b/src/components/forms/user/update/elements/Removal.tsx
@@ -1,0 +1,42 @@
+import { clsx } from "clsx";
+import { IconX } from "@tabler/icons-react";
+
+interface RemovalProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    handleRemovalClick: (e: React.MouseEvent<HTMLInputElement>) => void;
+    isBlocked: boolean;
+    currentImg: string;
+}
+
+export const Removal = ({ name, handleRemovalClick, isBlocked, currentImg, className, ...rest }: RemovalProps) => {
+
+    const shouldHideRemoval: boolean = currentImg === null || currentImg === '/imgs/banner.png';
+
+    if (isBlocked || shouldHideRemoval) return <></>;
+
+    return (
+        <>
+            <input
+                aria-label="Remover"
+                id={name}
+                type="button"
+                className="hidden"
+                onClick={handleRemovalClick}
+                {...rest}
+            />
+            <label
+                htmlFor={name}
+                className={clsx(
+                    'cursor-pointer',
+                    'rounded-full p-2',
+                    'backdrop-blur-[2px]',
+                    'bg-alpha-d-md',
+                    'hover:bg-alpha-d-sm transition-all',
+                    className
+                )}
+            >
+                <IconX color="white" />
+            </label>
+        </>
+    )
+
+}

--- a/src/components/forms/user/update/elements/Upload.tsx
+++ b/src/components/forms/user/update/elements/Upload.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, forwardRef, InputHTMLAttributes } from "react";
+import { clsx } from "clsx";
 import { editUserFormSchema } from "@/core";
 import { IconCameraPlus, IconForbid } from "@tabler/icons-react";
 
@@ -8,13 +9,13 @@ interface UploadProps extends InputHTMLAttributes<HTMLInputElement> {
     isBlocked: boolean;
 }
 
-export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleFileChange, isBlocked, ...rest }, ref) => {
+export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleFileChange, isBlocked, className, ...rest }, ref) => {
 
     return (
         <>
             <input
                 disabled={isBlocked}
-                aria-label="Zoom"
+                aria-label="Carregar"
                 id={name}
                 ref={ref}
                 type="file"
@@ -25,11 +26,14 @@ export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleF
             />
             <label
                 htmlFor={name}
-                className="cursor-pointer center
-                rounded-full p-2
-                backdrop-blur-[2px]
-                bg-alpha-d-md
-                hover:bg-alpha-d-sm transition-all"
+                className={clsx(
+                    'cursor-pointer',
+                    'rounded-full p-2',
+                    'backdrop-blur-[2px]',
+                    'bg-alpha-d-md',
+                    'hover:bg-alpha-d-sm transition-all',
+                    className
+                )}
             >
                 {isBlocked ? <IconForbid color="white" /> : <IconCameraPlus color="white" />}
             </label>

--- a/src/components/forms/user/update/elements/Upload.tsx
+++ b/src/components/forms/user/update/elements/Upload.tsx
@@ -1,17 +1,19 @@
 import { ChangeEvent, forwardRef, InputHTMLAttributes } from "react";
 import { editUserFormSchema } from "@/core";
-import { IconCameraPlus } from "@tabler/icons-react";
+import { IconCameraPlus, IconForbid } from "@tabler/icons-react";
 
 interface UploadProps extends InputHTMLAttributes<HTMLInputElement> {
     name: keyof typeof editUserFormSchema.shape;
     handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    isBlocked: boolean;
 }
 
-export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleFileChange, ...rest }, ref) => {
+export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleFileChange, isBlocked, ...rest }, ref) => {
 
     return (
         <>
             <input
+                disabled={isBlocked}
                 aria-label="Zoom"
                 id={name}
                 ref={ref}
@@ -27,9 +29,9 @@ export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleF
                 rounded-full p-2
                 backdrop-blur-[2px]
                 bg-alpha-d-md
-                hover:bg-alpha-d-sm transition-all "
+                hover:bg-alpha-d-sm transition-all"
             >
-                <IconCameraPlus color="white" />
+                {isBlocked ? <IconForbid color="white" /> : <IconCameraPlus color="white" />}
             </label>
         </>
     )

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -37,8 +37,8 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
         startTransition(async () => {
 
             const newData = { ...data };
-            const shouldUpdateAvatar = user.avatar !== data.avatar;
-            const shouldUpdateBanner = user.banner !== data.banner;
+            const shouldUpdateAvatar = !user.blocked && user.avatar !== data.avatar;
+            const shouldUpdateBanner = !user.blocked && user.banner !== data.banner;
 
             try {
 
@@ -141,6 +141,7 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     </div>
                 </Element.Main>
                 <ul>
+                    <li><Element.Link href="/help#blocked" target="_blank">Bloqueio</Element.Link></li>
                     <li><Element.Link href="/help#mutuals" target="_blank">Mútuos</Element.Link></li>
                     <li><Element.Link href="/settings/account">Configurações</Element.Link></li>
                 </ul>

--- a/src/core/models/user/User.ts
+++ b/src/core/models/user/User.ts
@@ -11,6 +11,7 @@ export interface User {
     host: string;
     profile_private: boolean;
     sponsor: boolean;
+    blocked: boolean;
     score: number;
     created_at: string;
     notifications: number;

--- a/src/data/contexts/UserContext.tsx
+++ b/src/data/contexts/UserContext.tsx
@@ -68,8 +68,8 @@ export const UserProvider = (props: any) => {
                     ...prev,
                     user: {
                         ...prev.user,
-                        avatar: avatar ?? prev.user.avatar,
-                        banner: banner ?? prev.user.banner,
+                        avatar: avatar !== undefined ? avatar : prev.user.avatar,
+                        banner: banner !== undefined ? banner : prev.user.banner,
                         profile_private: profile_private ?? prev.user.profile_private,
                         username: username ?? prev.user.username,
                         display_name: display_name ?? prev.user.display_name,

--- a/src/shared/releases/releases.ts
+++ b/src/shared/releases/releases.ts
@@ -17,6 +17,26 @@ export interface Release {
 
 export const releases: Release[] = [
     {
+        version: 'v1.6',
+        date: '26/09/25 14:00',
+        title: 'Setembro 26, 2025',
+        summary: 'Melhorias na segurança de imagem e no suporte ao perfil.',
+        entries: [
+            {
+                type: 'feat',
+                pr: 3,
+                hash: 'aabd422c07ca4c839d2696ebb525417df9744c4d',
+                desc: 'Permitido a remoção da capa do perfil.'
+            },
+            {
+                type: 'feat',
+                pr: 3,
+                hash: 'bc1678ec66c91e6747673a625331f1a4253210c8',
+                desc: 'Implementado bloqueio para usuários que enviarem imagens impróprias. Usuários bloqueados não podem atualizar as imagens do perfil.'
+            }
+        ]
+    },
+    {
         version: 'v1.5',
         date: '17/09/25 12:34',
         title: 'Setembro 17, 2025',


### PR DESCRIPTION
### Sumário

Este PR introduz uma medida de segurança para impedir que usuários bloqueados atualizem imagens de perfil (avatar/banner), prevenindo envio de conteúdo impróprio. Além disso, permite que usuários removam o banner do perfil definindo-o como nulo.

### Alterações

- `README.md` atualizado para a release 1.6.
- Adicionada coluna booleana `blocked` ao modelo de usuário.
- Validação do campo `blocked` nas requisições de atualização de avatar e banner.
- Refatoração para aceitar atualizar valor nulo no campo `banner` no estado de usuário.
- Atualizada rota /changelog para atender a nova atualização.

### Necessidade

- Impedir ações de trolls ou usuários bloqueados que tentem enviar conteúdo impróprio.
- Permitir maior flexibilidade na edição de perfil incluindo a remoção do banner.

### Teste Manual

1. Rode a aplicação.
2. Crie um usuário e tente atualizar o banner com um valor válido ou `null`.
3. Marque algum usuário como `blocked` e tente atualizar a imagem de perfil — a operação deve ser negada.

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados
