### PR TITLE
fix(username): support GitHub-style usernames with hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.6">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.6-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/1.6.1">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-1.6.1-7c3aed">
   </a>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notehub",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(pages)/changelog/elements/ReleaseTopic.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseTopic.tsx
@@ -1,4 +1,4 @@
-import { IconBoltFilled, IconBookFilled, IconFileTypeCss, IconFlaskFilled, IconLockFilled, IconPackage, IconRecycle, IconSparkles } from "@tabler/icons-react";
+import { IconBoltFilled, IconBookFilled, IconBugFilled, IconFileTypeCss, IconFlaskFilled, IconLockFilled, IconPackage, IconRecycle, IconSparkles } from "@tabler/icons-react";
 import { ReleaseEntryType } from "@/shared";
 
 interface TopicProps extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -38,7 +38,7 @@ export const ReleaseTopic = ({ type, children, ...rest }: ReleaseTopicProps) => 
 
     if (type === 'fix') return (
         <li className="flex flex-col gap-3" {...rest}>
-            <Topic icon={IconSparkles}>Correção</Topic>
+            <Topic icon={IconBugFilled}>Correção</Topic>
             {children}
         </li>
     )

--- a/src/app/(pages)/changelog/elements/ReleaseUList.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseUList.tsx
@@ -1,6 +1,18 @@
-export const ReleaseUList = (props: React.HTMLAttributes<HTMLUListElement>) => (
+import { clsx } from "clsx";
+
+interface ReleaseUListProps extends React.HTMLAttributes<HTMLUListElement> {
+    isActive: boolean;
+}
+
+export const ReleaseUList = ({ isActive, ...rest }: ReleaseUListProps) => (
     <ul
-        className="pl-6 border-l-2 dark:border-secondary border-primary flex flex-col gap-6"
-        {...props}
+        className={clsx(
+            'pl-6',
+            isActive
+                ? 'border-l-4 dark:border-secondary border-primary'
+                : 'border-l-2 dark:border-middark/50 border-midlight/50',
+            'flex flex-col gap-6',
+        )}
+        {...rest}
     />
 )

--- a/src/app/(pages)/changelog/page.tsx
+++ b/src/app/(pages)/changelog/page.tsx
@@ -1,11 +1,17 @@
+'use client';
+
 import { Header, Release, ReleaseDesc, ReleaseOList, ReleaseTitle, ReleaseTopic, ReleaseUList } from "./elements";
 import { ReleaseEntryType, releases } from "@/shared";
+import { tryScrollTo } from "@/core";
+import { useEffect, useState } from "react";
 
 type ReleasesArray = typeof releases;
 type ReleaseType = ReleasesArray[number];
 type Entry = ReleaseType["entries"][number];
 
 const Page = () => {
+
+    const [currentVersion] = useState<string>(sessionStorage.getItem('scrollTo') ?? releases[0].version);
 
     const groupByType = (entries: Entry[]): Partial<Record<ReleaseEntryType, Entry[]>> =>
         entries.reduce<Partial<Record<ReleaseEntryType, Entry[]>>>((acc, e) => {
@@ -15,16 +21,20 @@ const Page = () => {
             return acc;
         }, {})
 
+    useEffect(() => {
+        return tryScrollTo();
+    }, [])
+
     return (
         <main className="max-w-full w-screen insm:px-3 flex flex-col gap-12">
             <Header />
-            <div className="max-w-[666px] w-full mx-auto flex flex-col gap-12">
+            <div className="max-w-[666px] w-full mx-auto pb-24 flex flex-col gap-12">
                 {releases.map((release: ReleaseType) => {
                     const grouped = groupByType(release.entries);
                     return (
-                        <Release key={release.version}>
+                        <Release key={release.version} id={release.version}>
                             <ReleaseTitle tag={release.version}>({release.title})</ReleaseTitle>
-                            <ReleaseUList>
+                            <ReleaseUList isActive={currentVersion === release.version}>
                                 {(Object.entries(grouped) as [ReleaseEntryType, Entry[]][]).map(([type, entries]) => (
                                     <ReleaseTopic key={type} type={type}>
                                         <ReleaseOList>

--- a/src/app/(pages)/dashboard/user/aside/changelog/elements/Change.tsx
+++ b/src/app/(pages)/dashboard/user/aside/changelog/elements/Change.tsx
@@ -1,3 +1,4 @@
+import { scrollTo } from "@/core";
 import Link, { LinkProps } from "next/link";
 
 interface ChangeProps extends Omit<LinkProps, 'href'> {
@@ -5,23 +6,13 @@ interface ChangeProps extends Omit<LinkProps, 'href'> {
     children: React.ReactNode;
 }
 
-export const Change = ({ toId, children, ...rest }: ChangeProps) => {
-
-    const handleClick = (): void => {
-        const element = document.getElementById(toId);
-        if (element) return element.scrollIntoView({ behavior: "smooth", block: "start" });
-        return;
-    }
-
-    return (
-        <Link
-            href='/changelog'
-            onClick={handleClick}
-            className="font-medium text-sm hover:underline hover:text-secondary"
-            {...rest}
-        >
-            {children}
-        </Link>
-    )
-
-}
+export const Change = ({ toId, children, ...rest }: ChangeProps) => (
+    <Link
+        href='/changelog'
+        onClickCapture={scrollTo(toId)}
+        className="font-medium text-sm hover:underline hover:text-secondary"
+        {...rest}
+    >
+        {children}
+    </Link>
+)

--- a/src/app/(pages)/dashboard/welcome/index.tsx
+++ b/src/app/(pages)/dashboard/welcome/index.tsx
@@ -58,7 +58,7 @@ export const Welcome = (props: React.HTMLAttributes<HTMLElement>) => {
                     <Item href="/terms">Termos de Serviço</Item>
                     <Item href="/policy">Política de Privacidade</Item>
                     <Item href="/cookies">Cookies</Item>
-                    <Item href="/help" target="_blank">Ajuda</Item>
+                    <Item href="/help">Ajuda</Item>
                     <Item href="mailto:suporte@notehub.com.br">Suporte</Item>
                 </ul>
             </footer> */}

--- a/src/app/(pages)/help/elements/Answer.tsx
+++ b/src/app/(pages)/help/elements/Answer.tsx
@@ -1,36 +1,24 @@
 import { clsx } from "clsx";
-import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 
 interface AnswerProps extends React.HTMLAttributes<HTMLParagraphElement> {
+    currentId: string;
     hash: string;
     useSupport?: boolean;
 }
 
-export const Answer = ({ hash, useSupport, children, ...rest }: AnswerProps) => {
+export const Answer = ({ currentId, hash, useSupport, children, ...rest }: AnswerProps) => {
 
-    const [isActive, setIsActive] = useState<boolean>(hash === window.location.hash);
-
-    const handleHashChange = useCallback(() => {
-        if (hash === window.location.hash) return setIsActive(true);
-        else return setIsActive(false);
-    }, [hash])
-
-    useEffect(() => {
-        window.addEventListener("hashchange", handleHashChange);
-        return () => {
-            window.removeEventListener("hashchange", handleHashChange);
-        }
-    }, [handleHashChange])
+    const isActive: boolean = hash === currentId;
 
     return (
         <>
             <p
                 className={clsx(
-                    'overflow-hidden',
-                    isActive ? 'mt-3 max-h-[333px]' : 'mt-0 max-h-0',
+                    'overflow-hidden origin-top-left',
+                    isActive ? 'h-auto mt-3 scale-100' : 'h-0 mt-0 scale-0',
                     'text-sm dark:text-midlight/75 text-middark/75',
-                    'transition-all duration-300'
+                    'transition-all duration-500'
                 )}
                 {...rest}
             >

--- a/src/app/(pages)/help/elements/Header.tsx
+++ b/src/app/(pages)/help/elements/Header.tsx
@@ -11,7 +11,6 @@ export const Header = () => {
         <header>
             <Link
                 href="/"
-                target="blank"
                 className={clsx(
                     'group overflow-hidden block',
                     useDarkTheme ? "dark-navigate-logo" : "light-navigate-logo",

--- a/src/app/(pages)/help/elements/Question.tsx
+++ b/src/app/(pages)/help/elements/Question.tsx
@@ -1,34 +1,28 @@
 import { clsx } from "clsx";
 import { IconPlus } from "@tabler/icons-react";
-import { useCallback, useEffect, useState } from "react";
+import { setScrollTo } from "@/core";
 
 interface QuestionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    currentId: string;
+    setCurrentId: React.Dispatch<React.SetStateAction<string>>;
     hash: string;
     children: React.ReactNode;
 }
 
-export const Question = ({ hash, children, ...rest }: QuestionProps) => {
+export const Question = ({ currentId, setCurrentId, hash, children, ...rest }: QuestionProps) => {
 
-    const [isActive, setIsActive] = useState<boolean>(hash === window.location.hash);
+    const isActive: boolean = hash === currentId;
 
-    const updateHash = () => window.location.hash = hash;
-
-    const handleHashChange = useCallback(() => {
-        if (hash === window.location.hash) return setIsActive(true);
-        else return setIsActive(false);
-    }, [hash])
-
-    useEffect(() => {
-        window.addEventListener("hashchange", handleHashChange);
-        return () => {
-            window.removeEventListener("hashchange", handleHashChange);
-        }
-    }, [handleHashChange])
+    const updateCurrentId = (): void => {
+        setScrollTo(hash);
+        setCurrentId(hash);
+        return;
+    }
 
     return (
         <button
             disabled={isActive}
-            onClick={updateHash}
+            onClickCapture={updateCurrentId}
             className={clsx(
                 'group',
                 'w-full h-full',

--- a/src/app/(pages)/help/items.tsx
+++ b/src/app/(pages)/help/items.tsx
@@ -1,7 +1,6 @@
 export interface Items {
     id: string;
     keywords: string[];
-    hash: string;
     question: string;
     answer: React.ReactNode;
     useSupport?: boolean;
@@ -11,14 +10,12 @@ export const items: Items[] = [
     {
         id: 'language',
         keywords: ["language", "idioma", "linguagem", "português", "portugues", "tempo", "gmt", "hora"],
-        hash: '#language',
         question: 'Idioma',
         answer: <>Atualmente, a aplicação está disponível apenas em Português (PT-BR) e opera no fuso horário GMT-3.</>
     },
     {
         id: 'security',
         keywords: ["security", "segurança", "seguranca", "senha", "email", "conta"],
-        hash: '#security',
         question: 'Segurança',
         answer: (
             <>
@@ -32,7 +29,6 @@ export const items: Items[] = [
     {
         id: 'delete',
         keywords: ["delete", "excluir", "apagar", "conta", "remoção", "remover", "cancelar"],
-        hash: '#delete',
         question: 'Exclusão da conta',
         answer: (
             <>
@@ -47,7 +43,6 @@ export const items: Items[] = [
     {
         id: 'history',
         keywords: ["history", "histórico", "historico", "dados", "alterações", "alteracoes", "mudanças", "mudancas"],
-        hash: '#history',
         question: 'Histórico',
         answer: (
             <>
@@ -61,7 +56,6 @@ export const items: Items[] = [
     {
         id: 'searches',
         keywords: ["searches", "pesquisas", "buscas", "procura", "consultas"],
-        hash: '#searches',
         question: 'Pesquisas',
         answer: (
             <>
@@ -73,7 +67,6 @@ export const items: Items[] = [
     {
         id: 'sponsors',
         keywords: ["sponsors", "patrocinadores", "patrocínio", "patrocionio", "verificado", "patrocinar", "apoiar", "apoio"],
-        hash: '#sponsors',
         question: 'Patrocinador',
         answer: (
             <>
@@ -86,7 +79,6 @@ export const items: Items[] = [
     {
         id: 'privacy',
         keywords: ["privacy", "privacidade", "visibilidade", "conta", "perfil", "privado", "privar"],
-        hash: '#privacy',
         question: 'Privacidade',
         answer: (
             <>
@@ -101,7 +93,6 @@ export const items: Items[] = [
     {
         id: 'mutuals',
         keywords: ["mutuals", "mútuos", "iguais", "relação", "relacao", "relacionamento"],
-        hash: '#mutuals',
         question: 'Mútuos',
         answer: (
             <>
@@ -115,14 +106,12 @@ export const items: Items[] = [
     {
         id: 'hiddenNotes',
         keywords: ["hiddennotes", "hidden", "notes", "notas", "ocultas", "privadas"],
-        hash: '#hiddenNotes',
         question: 'Notas ocultas',
         answer: <>Notas ocultas são visíveis apenas para quem as criou, embora contabilizem na contagem total de notas.</>
     },
     {
         id: 'closedNotes',
         keywords: ["closednotes", "closed", "notes", "notas", "fechadas", "trancadas", "bloqueadas"],
-        hash: '#closedNotes',
         question: 'Notas fechadas',
         answer: (
             <>
@@ -136,7 +125,6 @@ export const items: Items[] = [
     {
         id: 'notifications',
         keywords: ["notifications", "notificações", "notificacoes", "alertas", "sino", "mensagens"],
-        hash: '#notifications',
         question: 'Notificações',
         answer: (
             <>
@@ -150,7 +138,6 @@ export const items: Items[] = [
     {
         id: 'feed',
         keywords: ["feed", "início", "inicio", "principal", "central"],
-        hash: '#feed',
         question: 'Feed',
         answer: (
             <>
@@ -164,7 +151,6 @@ export const items: Items[] = [
     {
         id: 'report',
         keywords: ["repots", "denúncias", "denuncias", "avisar", "suporte"],
-        hash: '#report',
         question: 'Denúncia',
         answer: (
             <>
@@ -179,7 +165,6 @@ export const items: Items[] = [
     {
         id: 'blocked',
         keywords: ["blocked", "block", "bloqueio", "bloqueado", "proibido", "excluido", "apagado", "cancelado", "silenciado", "suporte"],
-        hash: '#blocked',
         question: 'Bloqueio',
         answer: (
             <>
@@ -194,7 +179,6 @@ export const items: Items[] = [
     {
         id: 'ban',
         keywords: ["ban", "banir", "banido", "banimento", "excluído", "excluido", "apagado", "cancelado", "silenciado", "suporte"],
-        hash: '#ban',
         question: 'Banimento',
         answer: (
             <>
@@ -207,7 +191,6 @@ export const items: Items[] = [
     {
         id: 'other',
         keywords: ["others", "outras", "outros", "suporte", "email", "mensagem"],
-        hash: '#other',
         question: 'Outra',
         answer: (
             <>

--- a/src/app/(pages)/help/page.tsx
+++ b/src/app/(pages)/help/page.tsx
@@ -2,10 +2,12 @@
 
 import { Element } from "./elements";
 import { Items, items } from "./items";
+import { tryScrollTo } from "@/core";
 import { useEffect, useState } from "react";
 
 const Page = () => {
 
+    const [currentId, setCurrentId] = useState<string>(sessionStorage.getItem('scrollTo') ?? 'none');
     const [query, setQuery] = useState<string>("");
 
     const filteredItems = query.length > 0
@@ -13,12 +15,8 @@ const Page = () => {
         : [] as Items[];
 
     useEffect(() => {
-        if (window.location.hash) {
-            const id = window.location.hash.slice(1);
-            const element = document.getElementById(id);
-            if (element) element.scrollIntoView({ behavior: "smooth", block: "start" });
-        }
-    }, [])
+        return tryScrollTo();
+    }, [currentId])
 
     const { Header, Input, Li, Question, Answer } = Element;
 
@@ -39,8 +37,8 @@ const Page = () => {
                             ?
                             filteredItems.map((item) => (
                                 <Li key={item.id} id={item.id}>
-                                    <Question hash={item.hash}>{item.question}</Question>
-                                    <Answer hash={item.hash} useSupport={item.useSupport}>
+                                    <Question currentId={currentId} setCurrentId={setCurrentId} hash={item.id}>{item.question}</Question>
+                                    <Answer currentId={currentId} hash={item.id} useSupport={item.useSupport}>
                                         {item.answer}
                                     </Answer>
                                 </Li>
@@ -48,8 +46,8 @@ const Page = () => {
                             :
                             items.map((item) => (
                                 <Li key={item.id} id={item.id}>
-                                    <Question hash={item.hash}>{item.question}</Question>
-                                    <Answer hash={item.hash} useSupport={item.useSupport}>
+                                    <Question currentId={currentId} setCurrentId={setCurrentId} hash={item.id}>{item.question}</Question>
+                                    <Answer currentId={currentId} hash={item.id} useSupport={item.useSupport}>
                                         {item.answer}
                                     </Answer>
                                 </Li>

--- a/src/app/(pages)/sent/page.tsx
+++ b/src/app/(pages)/sent/page.tsx
@@ -27,7 +27,7 @@ const Page = () => {
         >
             <SVG.Flare className="absolute" />
             <header>
-                <Link href={'/'} target="blank" className="z-[1] group relative">
+                <Link href='/' className="z-[1] group relative">
                     <Icon.Logo width={300} height={0} />
                 </Link>
             </header>

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/Warnings.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/Warnings.tsx
@@ -1,3 +1,4 @@
+import { scrollTo } from "@/core";
 import Link from "next/link";
 
 export const Warnings = () => (
@@ -9,7 +10,10 @@ export const Warnings = () => (
         <ol className="list-inside list-disc font-medium text-sm dark:text-midlight/60 text-middark/60">
             <li>
                 Notas criadas.
-                <Link href="/help#delete" className="ml-1 dark:text-secondary text-primary hover:underline">
+                <Link
+                    href="/help"
+                    onClickCapture={scrollTo('delete')}
+                    className="ml-1 dark:text-secondary text-primary hover:underline">
                     Saiba mais
                 </Link>
             </li>

--- a/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/Warnings.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/delete/elements/Warnings.tsx
@@ -9,11 +9,7 @@ export const Warnings = () => (
         <ol className="list-inside list-disc font-medium text-sm dark:text-midlight/60 text-middark/60">
             <li>
                 Notas criadas.
-                <Link
-                    href="/help#delete"
-                    target="_blank"
-                    className="ml-1 dark:text-secondary text-primary hover:underline"
-                >
+                <Link href="/help#delete" className="ml-1 dark:text-secondary text-primary hover:underline">
                     Saiba mais
                 </Link>
             </li>

--- a/src/app/(pages)/settings/(pages)/account/(pages)/visibility/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/visibility/page.tsx
@@ -3,6 +3,7 @@
 import { clsx } from "clsx";
 import { Header } from "../../../Header";
 import { Icon } from "@/components/icons";
+import { scrollTo } from "@/core";
 import { useServices, useUser } from "@/data/hooks";
 import { useTransition } from "react";
 import Link from "next/link";
@@ -61,7 +62,7 @@ const Page = () => {
                     Quando sua conta está privada, apenas mútuos podem visualizar suas notas, suas chamas, seus seguidores e quem você segue
                     — salvo notas ocultas.
                     <span className="ml-1 text-secondary hover:underline">
-                        <Link href="/help#mutuals">Saiba mais</Link>
+                        <Link href="/help" onClickCapture={scrollTo('mutuals')}>Saiba mais</Link>
                     </span>
                 </p>
             </section>

--- a/src/app/(pages)/settings/(pages)/account/(pages)/visibility/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/visibility/page.tsx
@@ -61,7 +61,7 @@ const Page = () => {
                     Quando sua conta está privada, apenas mútuos podem visualizar suas notas, suas chamas, seus seguidores e quem você segue
                     — salvo notas ocultas.
                     <span className="ml-1 text-secondary hover:underline">
-                        <Link href={"/help#mutuals"} target="_blank" >Saiba mais</Link>
+                        <Link href="/help#mutuals">Saiba mais</Link>
                     </span>
                 </p>
             </section>

--- a/src/app/(pages)/settings/elements/Aside.tsx
+++ b/src/app/(pages)/settings/elements/Aside.tsx
@@ -22,7 +22,7 @@ export const Aside = ({ onDesktop, onPathname, ...rest }: AsideProps) => {
                 <Link icon={IconChevronRight} href="/settings/account">Conta</Link>
                 <Link icon={IconChevronRight} href="/settings/appearance">Aparência</Link>
                 <Link icon={IconChevronRight} href="/settings/sponsorship">Patrocínio</Link>
-                <Link icon={IconHelp} href="/help" target="_blank">Ajuda</Link>
+                <Link icon={IconHelp} href="/help">Ajuda</Link>
             </ul>
         </aside>
     )

--- a/src/components/devices/desktop/navbar/dropdown/contents/MenuDropdown.tsx
+++ b/src/components/devices/desktop/navbar/dropdown/contents/MenuDropdown.tsx
@@ -51,7 +51,7 @@ export const MenuDropdown = ({ user }: { user: User }) => {
                 <Field.Link href={'/settings/account'} text="Configurações"><IconSettings /></Field.Link>
             </Section>
             <Section>
-                <Field.Link href="/help" target="_blank" text="Ajuda">
+                <Field.Link href="/help" text="Ajuda">
                     <IconHelp />
                 </Field.Link>
                 <Field.Link href="mailto:contato@notehub.com.br" text="Enviar feedback">

--- a/src/components/forms/auth/signin/index.tsx
+++ b/src/components/forms/auth/signin/index.tsx
@@ -112,7 +112,7 @@ export const Form = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
                     <Element.Label htmlFor="password">Senha</Element.Label>
                     <Element.Input name="password" type="password" autoComplete="on" required />
                     <Element.Error field="password" />
-                    <Link href={'/recover'} target='blank' className='w-fit mt-2 mb-4' tabIndex={1}>
+                    <Link href='/recover' className='w-fit mt-2 mb-4' tabIndex={1}>
                         <span className='request-btn underline p-1 font-semibold text-sm text-secondary'>Esqueceu a senha?</span>
                     </Link>
                 </Element.Field>

--- a/src/components/forms/user/update/elements/Link.tsx
+++ b/src/components/forms/user/update/elements/Link.tsx
@@ -1,10 +1,10 @@
 import { IconChevronRight } from "@tabler/icons-react";
 import NextLink, { LinkProps } from "next/link";
 
-export const Link = ({ children, target = "_self", ...rest }: { children: React.ReactNode, target?: "_self" | "_blank" } & LinkProps) => {
+export const Link = ({ children, onClick, ...rest }: { children: React.ReactNode } & LinkProps) => {
     return (
         <NextLink
-            target={target}
+            onClickCapture={onClick}
             className="px-4 py-3 flex items-center gap-3
             hover:dark:bg-lighter/10 hover:bg-darker/10"
             {...rest}

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -1,6 +1,6 @@
 import { clsx } from "clsx";
 import { deleteImage, storeImg } from "@/supabase";
-import { EditUserFormData, editUserFormSchema, handleFieldErrors } from "@/core";
+import { EditUserFormData, editUserFormSchema, handleFieldErrors, scrollTo } from "@/core";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { forwardRef, useState, useTransition } from "react";
@@ -141,8 +141,8 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     </div>
                 </Element.Main>
                 <ul>
-                    <li><Element.Link href="/help#blocked">Bloqueio</Element.Link></li>
-                    <li><Element.Link href="/help#mutuals">Mútuos</Element.Link></li>
+                    <li><Element.Link href="/help" onClick={scrollTo('blocked')}>Bloqueio</Element.Link></li>
+                    <li><Element.Link href="/help" onClick={scrollTo('mutuals')}>Mútuos</Element.Link></li>
                     <li><Element.Link href="/settings/account">Configurações</Element.Link></li>
                 </ul>
             </form>

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -141,8 +141,8 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     </div>
                 </Element.Main>
                 <ul>
-                    <li><Element.Link href="/help#blocked" target="_blank">Bloqueio</Element.Link></li>
-                    <li><Element.Link href="/help#mutuals" target="_blank">Mútuos</Element.Link></li>
+                    <li><Element.Link href="/help#blocked">Bloqueio</Element.Link></li>
+                    <li><Element.Link href="/help#mutuals">Mútuos</Element.Link></li>
                     <li><Element.Link href="/settings/account">Configurações</Element.Link></li>
                 </ul>
             </form>

--- a/src/core/schemas/user/CreateUser.ts
+++ b/src/core/schemas/user/CreateUser.ts
@@ -7,7 +7,7 @@ export const createUserFormSchema = z.object({
         .email('Email inválido.'),
     username: noForbiddenWords("Não pode")(z
         .string().trim().toLowerCase()
-        .regex(/^[a-zA-Z0-9_.]+$/, "Use letras, números, _ ou .")
+        .regex(/^[a-zA-Z0-9_.-]+$/, "Use letras, números, _, . ou -")
         .min(2, 'Mínimo de 2 caracteres.')
         .max(12, 'Máximo de 12 caracteres.')),
     displayName: noForbiddenWords("Não pode")(z

--- a/src/core/schemas/user/EditUser.ts
+++ b/src/core/schemas/user/EditUser.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export const editUserFormSchema = z.object({
     username: noForbiddenWords("Não pode")(z
         .string().trim().toLowerCase()
-        .regex(/^[a-zA-Z0-9_.]+$/, "Use letras, números, _ ou .")
+        .regex(/^[a-zA-Z0-9_.-]+$/, "Use letras, números, _, . ou -")
         .min(2, 'Mínimo de 2 caracteres.')
         .max(12, 'Máximo de 12 caracteres.')),
     displayName: noForbiddenWords("Não pode")(z

--- a/src/core/schemas/user/LoginUser.ts
+++ b/src/core/schemas/user/LoginUser.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export const loginUserFormSchema = z.object({
     username: noForbiddenWords("Não pode")(z
         .string().trim().toLowerCase()
-        .regex(/^[a-zA-Z0-9_.]+$/, "Use letras, números, _ ou .")
+        .regex(/^[a-zA-Z0-9_.-]+$/, "Use letras, números, _, . ou -")
         .min(2, 'Mínimo de 2 caracteres.')
         .max(12, 'Máximo de 12 caracteres.')),
     password: z

--- a/src/core/utils/ScrollTo.ts
+++ b/src/core/utils/ScrollTo.ts
@@ -1,0 +1,21 @@
+export const scrollTo = (id: string): React.MouseEventHandler<HTMLAnchorElement> => (): void => {
+    return sessionStorage.setItem('scrollTo', id);
+}
+
+export const setScrollTo = (id: string): void => {
+    return sessionStorage.setItem('scrollTo', id);
+}
+
+export const tryScrollTo = () => {
+    const id = sessionStorage.getItem('scrollTo');
+    if (id) {
+        sessionStorage.removeItem('scrollTo');
+        const tryScroll = () => {
+            const el = document.getElementById(id);
+            if (el) return el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            requestAnimationFrame(tryScroll);
+        }
+        return tryScroll();
+    }
+    return;
+}

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -9,3 +9,4 @@ export * from './Object';
 export * from './Query';
 export * from './Colors';
 export * from './Forbidden';
+export * from './ScrollTo';

--- a/src/data/contexts/UserContext.tsx
+++ b/src/data/contexts/UserContext.tsx
@@ -122,15 +122,15 @@ export const UserProvider = (props: any) => {
         }
     }
 
+    const init = useCallback(async (): Promise<void> => {
+        if (store.isFirstTimer || store.isGuest) return;
+        if (shouldUseUserContext(pathname)) return await fetchUser();
+    }, [fetchUser, pathname, store.isFirstTimer, store.isGuest])
+
     useEffect(() => {
-        if (!isStoreReady) return;
-        const init = async () => {
-            if (shouldUseUserContext(pathname) && !store.isFirstTimer && !store.isGuest) {
-                return await fetchUser();
-            }
-        }
-        init().finally(() => setState((prev) => ({ ...prev, isMounted: true })));
-    }, [isStoreReady])
+        if (state.user) return;
+        if (isStoreReady) init().finally(() => setState((prev) => ({ ...prev, isMounted: true })));
+    }, [isStoreReady, pathname])
 
     useEffect(() => {
         const fetchData = async () => {

--- a/src/shared/releases/releases.ts
+++ b/src/shared/releases/releases.ts
@@ -17,6 +17,20 @@ export interface Release {
 
 export const releases: Release[] = [
     {
+        version: 'v1.6.1',
+        date: '29/09/25 10:56',
+        title: 'Setembro 29, 2025',
+        summary: 'Suporte a nomes de usuários no estilo GitHub com hífen',
+        entries: [
+            {
+                type: 'fix',
+                pr: 4,
+                hash: '3e4ce2bc9ce9d2ea8fce92bcf0af8e5225ac05b8',
+                desc: 'Permitido hífen na atualização de nome de usuário.'
+            }
+        ]
+    },
+    {
         version: 'v1.6',
         date: '26/09/25 14:00',
         title: 'Setembro 26, 2025',


### PR DESCRIPTION
### Sumário

Este PR corrige a validação de username para aceitar hífen (-) (compatibilidade com usernames do GitHub), resolve um caso em que o contexto do usuário não era inicializado ao navegar entre rotas não-usuário/usuário e remove links baseados em hash, substituindo por um util ScrollTo para smooth scroll e navegação interna consistente.

### Alterações

- `package,json`, `README.md` e `/changelog` atualizados para a release **1.6.1**;
- Ajuste do fluxo de inicialização para garantir que, ao navegar para rotas que dependem do `UserContext.tsx`, a requisição de inicialização seja disparada caso o `Store.ts` ainda não esteja pronto e o usuário seja um usuário válido (não `Guest`/ não `FirstTimer`).
- Removido `target="_blank"` de links que apontavam para `/help` para manter a navegação dentro da aplicação.
- Removidos links que dependiam de fragment identifiers (hash) e substituídos por uma estratégia de navegação interna baseada em `ScrollTo` e `sessionStorage `para preservar posições e promover rolagem suave.

### Necessidade

- Usuários importados ou autenticados via GitHub que possuam hífen no username não conseguiam atualizar seu perfil devido à regex de validação atual.
- Em certas transições de rota o contexto do usuário não era inicializado corretamente (quando o armazém ainda não estava pronto, e o usuário não era visitante nem de primeira-viagem), deixando o carregamento de esqueleto preso.
- Links que abriam a rota de ajuda com target="_blank" quebravam o fluxo da aplicação SPA; além disso, o uso de links com hash foi removido em favor de uma navegação interna controlada e rolagem suave.

### Teste manual

- Rode a aplicação;
- Crie ou importe um usuário com username contendo hífen (ex.: vasco-da-gama).
- Navegue entre rotas não-usuário e rotas de usuário para reproduzir o caso onde o contexto poderia não estar inicializado — verificar que o esqueleto desaparece e os dados do usuário são carregados corretamente.
- Abra links para /help e confirme que não são abertos em nova aba; verifique também a rolagem suave quando navegar para âncoras internas (caso aplicável).

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados
