### PR TITLE
feat(auth): add password recovery flow (route, form, schemas, service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/1.6.1">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.6.1">
     <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-1.6.1-7c3aed">
   </a>
 </div>

--- a/src/app/(pages)/[username]/[id]/page.tsx
+++ b/src/app/(pages)/[username]/[id]/page.tsx
@@ -83,7 +83,7 @@ const Page = () => {
     )
 
     if (note) return (
-        <section className="max-w-[999px] w-full m-auto">
+        <section className="max-w-[999px] w-full m-auto pb-64">
             <section className="flex inlg:flex-col-reverse">
                 <Template.Portal blur="sm" triggerRef={triggerRef} childRef={childRef} closeRef={closeRef}>
                     <Form.Note.Update

--- a/src/app/(pages)/recover/page.tsx
+++ b/src/app/(pages)/recover/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { Component } from '@/components';
+import { Form } from '@/components/forms';
+import { Template } from '@/components/templates';
+
+const Page = () => {
+    return (
+        <Template.Container className='flex items-center justify-center p-2'>
+            <Component.TsParticles />
+            <Form.Auth.Recover />
+        </Template.Container>
+    )
+}
+
+export default Page;

--- a/src/components/forms/auth/index.ts
+++ b/src/components/forms/auth/index.ts
@@ -1,4 +1,5 @@
 import { Form as SignIn } from "./signin";
 import { Form as SignUp } from "./signup";
+import { Form as Recover } from './recover';
 
-export const Auth = { SignIn, SignUp };
+export const Auth = { SignIn, SignUp, Recover };

--- a/src/components/forms/auth/recover/elements/Button.tsx
+++ b/src/components/forms/auth/recover/elements/Button.tsx
@@ -1,0 +1,27 @@
+import { clsx } from "clsx";
+
+interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+    isRequesting?: boolean;
+}
+
+const Button = ({ isRequesting, ...rest }: ButtonProps) => {
+    return (
+        <button
+            className={clsx(
+                'ease-in-out transition-all duration-500',
+                isRequesting && "cursor-not-allowed",
+                !isRequesting && "request-btn",
+                !isRequesting && "relative active:top-[1px]",
+                'w-full m-auto py-2',
+                'rounded-md',
+                'text-md text-slate-100 font-semibold',
+                isRequesting ? "dark:bg-white/25 bg-black/25" : "dark:bg-slate-100/5 bg-dark/25"
+            )}
+            type="submit"
+            disabled={isRequesting}
+            {...rest}
+        />
+    );
+};
+
+export default Button;

--- a/src/components/forms/auth/recover/elements/Error.tsx
+++ b/src/components/forms/auth/recover/elements/Error.tsx
@@ -1,0 +1,23 @@
+import { RecoverFormData } from "@/core";
+import { useFormContext } from "react-hook-form";
+
+interface ErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {
+    field: keyof RecoverFormData;
+};
+
+const Error = ({ field, ...rest }: ErrorProps) => {
+
+    const { formState: { errors } } = useFormContext();
+
+    const error = errors[field]?.message;
+
+    if (!error) return null;
+
+    return (
+        <p className="px-1 text-sm font-bold dark:text-red-500 text-rose-500" {...rest} >
+            {error.toString()}
+        </p>
+    )
+};
+
+export default Error;

--- a/src/components/forms/auth/recover/elements/Field.tsx
+++ b/src/components/forms/auth/recover/elements/Field.tsx
@@ -1,0 +1,5 @@
+const Field = (props: React.HTMLAttributes<HTMLDivElement>) => {
+  return <div className="flex flex-col gap-3" {...props} />;
+};
+
+export default Field;

--- a/src/components/forms/auth/recover/elements/Header.tsx
+++ b/src/components/forms/auth/recover/elements/Header.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { clsx } from "clsx";
+import { Icon } from "@/components/icons";
+import { usePref } from "@/data/hooks";
+import Link from "next/link";
+
+const Header = () => {
+
+    const { pref: { useDarkTheme } } = usePref();
+
+    return (
+        <header>
+            <Link href="/"
+                className={clsx(
+                    'group overflow-hidden block',
+                    useDarkTheme ? "dark-navigate-logo" : "light-navigate-logo",
+                    'w-fit p-2 m-auto rounded-xl',
+                    'border-2 dark:border-primary/25 border-primary/25',
+                    'dark:bg-primary/5 bg-primary/5'
+                )}
+            >
+                <Icon.Logo width={125} height={0} />
+            </Link>
+        </header>
+    );
+};
+
+export default Header;

--- a/src/components/forms/auth/recover/elements/Input.tsx
+++ b/src/components/forms/auth/recover/elements/Input.tsx
@@ -1,0 +1,48 @@
+import { InputHTMLAttributes } from "react";
+import { RecoverFormData } from "@/core";
+import { useFormContext } from "react-hook-form";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+    name: keyof RecoverFormData;
+    icon?: React.ReactNode;
+};
+
+const Input = ({ name, icon, ...rest }: InputProps) => {
+
+    const { register } = useFormContext();
+
+    return (
+        <div className="flex items-center justify-between">
+            <input
+                id={name}
+                spellCheck={false}
+                autoCorrect="off"
+                autoCapitalize="off"
+                autoComplete="off"
+                {...register(name)}
+                className="outline-none
+                    peer
+                    w-full py-1 px-2
+                    text-md text-primary font-semibold
+                    border-2 dark:border-primary/40 border-primary/40 rounded-s-md
+                    dark:bg-dark bg-light
+                    dark:focus:border-primary dark:valid:border-primary
+                    focus:border-primary valid:border-primary"
+                {...rest}
+            />
+            <div
+                className="p-1
+                text-slate-100
+                border-2 border-transparent rounded-e-md
+                dark:bg-primary/25 bg-primary/35
+                dark:peer-focus:bg-primary dark:peer-valid:bg-primary
+                peer-focus:bg-primary peer-valid:bg-primary"
+            >
+                {icon}
+            </div>
+        </div>
+    )
+
+}
+
+export default Input;

--- a/src/components/forms/auth/recover/elements/Label.tsx
+++ b/src/components/forms/auth/recover/elements/Label.tsx
@@ -1,0 +1,31 @@
+import { LabelHTMLAttributes } from "react";
+import { IconQuestionMark } from "@tabler/icons-react";
+
+interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+    tooltip?: React.ReactNode;
+}
+
+const Label = ({ tooltip, ...rest }: LabelProps) => {
+    return (
+        <div className="flex items-center gap-1 px-1 ">
+            <label className="text-md dark:text-slate-100 text-dark" {...rest} />
+            {tooltip &&
+                <div className="group relative">
+                    <IconQuestionMark size={17} className="text-slate-100 rounded-full dark:bg-slate-300/50 bg-neutral-500" />
+                    <p className="cursor-help invisible opacity-0 group-hover:opacity-100 group-hover:visible
+                        transition-opacity duration-500
+                        absolute top-1/2 -translate-y-1/2 left-[125%]
+                        insm:left-1/2 -translate-x-1/2
+                        w-[150px] p-1
+                        rounded-md 
+                        text-sm  text-slate-100
+                        dark:bg-gray-500 bg-neutral-500 "
+                    >
+                        {tooltip}
+                    </p>
+                </div>}
+        </div>
+    )
+};
+
+export default Label;

--- a/src/components/forms/auth/recover/elements/index.tsx
+++ b/src/components/forms/auth/recover/elements/index.tsx
@@ -1,0 +1,8 @@
+import Header from "./Header";
+import Field from "./Field";
+import Label from "./Label";
+import Input from "./Input";
+import Error from "./Error";
+import Button from "./Button";
+
+export const Element = { Header, Field, Label, Input, Error, Button };

--- a/src/components/forms/auth/recover/index.tsx
+++ b/src/components/forms/auth/recover/index.tsx
@@ -1,0 +1,61 @@
+import { Element } from "./elements";
+import { FormProvider, useForm } from "react-hook-form";
+import { handleFieldErrors, RecoverFormData, recoverFormSchema } from "@/core";
+import { IconMail } from "@tabler/icons-react";
+import { useRouter } from "next/navigation";
+import { useServices } from "@/data/hooks";
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+export const Form = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
+
+    const { authService: { sendPasswordChangeRequest } } = useServices();
+
+    const recoverForm = useForm<RecoverFormData>({
+        resolver: zodResolver(recoverFormSchema)
+    })
+
+    const { handleSubmit, setError } = recoverForm;
+
+    const [isRequesting, setIsRequesting] = useState<boolean>();
+
+    const router = useRouter();
+
+    const onSubmit = async (data: RecoverFormData) => {
+        setIsRequesting(true)
+        try {
+            await sendPasswordChangeRequest(data);
+            router.push('/sent')
+        } catch (error: any) {
+            if (error.response.status === 404) return setError("email", { message: "Conta não encontrada." });
+            if (Array.isArray(error)) return handleFieldErrors(error, setError)
+            return;
+        } finally {
+            setIsRequesting(false)
+        }
+    }
+
+    return (
+        <FormProvider {...recoverForm}>
+            <form
+                onSubmit={handleSubmit(onSubmit)}
+                className="w-[444px] insm:w-full
+                    px-4 py-4
+                    flex flex-col gap-12
+                    rounded-md
+                    backdrop-blur-sm
+                    dark:bg-primary/20 bg-indigo-600/10"
+                {...props}
+            >
+                <Element.Header />
+                <Element.Field>
+                    <Element.Label htmlFor="email" tooltip="O email deve ser aquele vinculado à conta.">Email</Element.Label>
+                    <Element.Input name="email" type="text" icon={<IconMail title="Email" />} />
+                    <Element.Error field="email" />
+                </Element.Field>
+                <Element.Button isRequesting={isRequesting}>Enviar</Element.Button>
+            </form>
+        </FormProvider>
+    )
+
+}

--- a/src/components/forms/auth/signin/index.tsx
+++ b/src/components/forms/auth/signin/index.tsx
@@ -1,7 +1,7 @@
 import { Cookies, handleOAuthError } from "@/core";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
-import { handleFieldErrors, LoginUserFormData, loginUserFormSchema, Token, User } from "@/core";
+import { handleFieldErrors, LoginFormData, loginFormSchema, Token, User } from "@/core";
 import { IconAt } from "@tabler/icons-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useGoogleLogin } from "@react-oauth/google";
@@ -17,8 +17,8 @@ export const Form = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
     const { setStore } = useStore();
     const { setUser } = useUser();
 
-    const loginUserForm = useForm<LoginUserFormData>({
-        resolver: zodResolver(loginUserFormSchema)
+    const loginUserForm = useForm<LoginFormData>({
+        resolver: zodResolver(loginFormSchema)
     })
 
     const { handleSubmit, setError } = loginUserForm;
@@ -39,7 +39,7 @@ export const Form = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
         return router.push('/');
     }, [router, setStore, setUser])
 
-    const onSubmit = async (data: LoginUserFormData) => {
+    const onSubmit = async (data: LoginFormData) => {
         setState((prev) => ({ ...prev, isRequesting: true }));
         try {
             login(await loginUserByDefault(data));

--- a/src/core/schemas/auth/Login.ts
+++ b/src/core/schemas/auth/Login.ts
@@ -1,7 +1,7 @@
 import { noForbiddenWords } from '@/core/utils';
 import { z } from 'zod';
 
-export const loginUserFormSchema = z.object({
+export const loginFormSchema = z.object({
     username: noForbiddenWords("Não pode")(z
         .string().trim().toLowerCase()
         .regex(/^[a-zA-Z0-9_.-]+$/, "Use letras, números, _, . ou -")
@@ -13,4 +13,4 @@ export const loginUserFormSchema = z.object({
         .max(255, 'Máximo de 255 caracteres.'),
 });
 
-export type LoginUserFormData = z.infer<typeof loginUserFormSchema>;
+export type LoginFormData = z.infer<typeof loginFormSchema>;

--- a/src/core/schemas/auth/Recover.ts
+++ b/src/core/schemas/auth/Recover.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const recoverFormSchema = z.object({
+    email: z
+        .string().trim().toLowerCase()
+        .email('Email inválido.')
+});
+
+export type RecoverFormData = z.infer<typeof recoverFormSchema>;

--- a/src/core/schemas/auth/index.ts
+++ b/src/core/schemas/auth/index.ts
@@ -1,0 +1,5 @@
+import { LoginFormData, loginFormSchema } from './Login';
+import { RecoverFormData, recoverFormSchema } from './Recover';
+
+export type { LoginFormData, RecoverFormData };
+export { loginFormSchema, recoverFormSchema };

--- a/src/core/schemas/index.ts
+++ b/src/core/schemas/index.ts
@@ -1,6 +1,7 @@
 import { getSchemaStringConstraints } from './Constraints';
 
 export { getSchemaStringConstraints };
+export * from './auth';
 export * from './user';
 export * from './note';
 export * from './comment';

--- a/src/core/schemas/user/index.ts
+++ b/src/core/schemas/user/index.ts
@@ -1,24 +1,21 @@
 import { CreateUserFormData, createUserFormSchema } from "./CreateUser";
+import { DeleteUserFormData, deleteUserFormSchema } from "./DeleteUser";
 import { EditUserFormData, editUserFormSchema } from "./EditUser";
 import { EmailChangeFormData, emailChangeFormSchema } from "./UpdateEmail";
-import { LoginUserFormData, loginUserFormSchema } from "./LoginUser";
 import { PasswordUpdateFormData, passwordUpdateFormSchema } from "./UpdatePassword";
-import { DeleteUserFormData, deleteUserFormSchema } from "./DeleteUser";
 
 export type {
     CreateUserFormData,
-    LoginUserFormData,
+    DeleteUserFormData,
     EditUserFormData,
     EmailChangeFormData,
-    PasswordUpdateFormData,
-    DeleteUserFormData
+    PasswordUpdateFormData
 }
 
 export {
     createUserFormSchema,
-    loginUserFormSchema,
+    deleteUserFormSchema,
     editUserFormSchema,
     emailChangeFormSchema,
-    passwordUpdateFormSchema,
-    deleteUserFormSchema
+    passwordUpdateFormSchema
 }

--- a/src/core/utils/Forbidden.ts
+++ b/src/core/utils/Forbidden.ts
@@ -6,7 +6,7 @@ const forbiddenWords: string[] = [
     "israel", "israeli", "aisraeli", "israelita", "umisraelita", "israelit", "aisraelit",
     "null", "undefined", "admin", "user", "guest",
     "toe", "terms", "termos", "policies", "policy", "cookies", "cookie", "privacy", "legal", "legals", "language", "idioma",
-    "signup", "signin", "sent", "activate", "search", "settings", "new", "help", "changelog", "dashboard",
+    "signup", "signin", "recover", "sent", "activate", "search", "settings", "new", "help", "changelog", "dashboard",
     "crf", "crfla", "crflamengo", "flamengo", "fla", "tjf", "t.j.f", "jovemfla", "jovem.fla", "jovem_fla",
     "ffc", "flufc", "fluminensefc", "fluminese", "flu", "tyf", "t.y.f", "youngflu", "young.flu", "young_flu",
     "tcp", "t.c.p", "tcpuro",

--- a/src/core/utils/Routes.ts
+++ b/src/core/utils/Routes.ts
@@ -2,6 +2,7 @@ export enum Routes {
     BASE = '/',
     SIGNUP = '/signup',
     SIGNIN = '/signin',
+    RECOVER = '/recover',
     SENT = '/sent',
     ACTIVATE = '/activate/:jwt',
     SEARCH_DESKTOP = '/search',
@@ -30,6 +31,7 @@ export enum Routes {
 enum NotUserContextRoutes {
     SIGNUP = '/signup',
     SIGNIN = '/signin',
+    RECOVER = '/recover',
     SENT = '/sent',
     ACTIVATE = '/activate/:jwt',
     CHANGE_EMAIL = '/change/email',

--- a/src/data/hooks/useAPI.ts
+++ b/src/data/hooks/useAPI.ts
@@ -23,6 +23,7 @@ const createHeaders = (
 }
 
 const handleResponse = async (response: Response) => {
+
     if (response.status === 204) return null;
 
     const text = await response.text();
@@ -32,14 +33,11 @@ const handleResponse = async (response: Response) => {
     } catch {
         data = text;
     }
-    if (!response.ok) {
-        if (response.status === 404) {
-            throw data || new Error();
-        }
-        throw data;
-    }
 
-    return data;
+    if (response.ok) return data;
+    if (response.status === 404) throw { data, response };
+    throw data;
+
 }
 
 export const useAPI = () => {

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -1,4 +1,4 @@
-import { LoginUserFormData, Token, User, Cookies } from "@/core";
+import { LoginFormData, Token, User, Cookies, RecoverFormData } from "@/core";
 import { useAPI, useUser } from "@/data/hooks";
 import { useCallback } from "react";
 
@@ -8,7 +8,7 @@ export const AuthService = () => {
 
     const { updateToken } = useUser();
 
-    const loginUserByDefault = async (data: LoginUserFormData): Promise<{ token: Token, user: User }> => {
+    const loginUserByDefault = async (data: LoginFormData): Promise<{ token: Token, user: User }> => {
         try {
             return await httpPost('/auth/login', data, { useProgress: true });
         } catch (error) {
@@ -74,9 +74,9 @@ export const AuthService = () => {
         }
     }, [httpPost])
 
-    const sendPasswordChangeRequest = useCallback(async (email: { email: string }): Promise<void> => {
+    const sendPasswordChangeRequest = useCallback(async (data: RecoverFormData | { email: string }): Promise<void> => {
         try {
-            return await httpPost('/auth/change-password', email, { useProgress: true });
+            return await httpPost('/auth/change-password', data, { useProgress: true });
         } catch (error) {
             throw error;
         }


### PR DESCRIPTION
### Sumário

Este PR adiciona o fluxo de recuperação de senha, incluindo rota, página e formulário.

### Alterações

- Corrigido link para a última release no `README.md` (**1.6.1**);
- Criada página para a rota `/recover`.

### Motivação

É necessário permitir que usuários recuperem suas contas em caso de perda da senha atual.

### Teste manual

1. Rode a aplicação;
2. Crie um novo usuário e ative-o;
3. Acesse a rota `/recover` e solicite uma nova senha;
4. Acesse o email referente a recuperação;
5. Redefina a senha e acesse a conta.

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados
