### PR TITLE
feat(topic): add user subscriptions UI and topic-based notifications management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.6.1">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-1.6.1-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v1.7">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-1.7-7c3aed">
   </a>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notehub",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(pages)/changelog/page.tsx
+++ b/src/app/(pages)/changelog/page.tsx
@@ -39,7 +39,7 @@ const Page = () => {
                                     <ReleaseTopic key={type} type={type}>
                                         <ReleaseOList>
                                             {entries.map((entry: Entry, idx: number) => (
-                                                <ReleaseDesc key={entry.hash ?? idx} pr={entry.pr} hash={entry.hash}>
+                                                <ReleaseDesc key={idx} pr={entry.pr} hash={entry.hash}>
                                                     {entry.desc}
                                                 </ReleaseDesc>
                                             ))}

--- a/src/app/(pages)/dashboard/welcome/index.tsx
+++ b/src/app/(pages)/dashboard/welcome/index.tsx
@@ -9,10 +9,10 @@ export const Welcome = (props: React.HTMLAttributes<HTMLElement>) => {
     return (
         <main className="w-full h-full flex flex-col dark:bg-darker bg-lighter" {...props}>
             <div className="w-full flex-1 flex inmd:flex-col inmd:justify-center gap-8 inmd:gap-6">
-                <section className="inmd:w-full inmd:max-w-[333px] px-3 mx-auto flex flex-col items-center justify-center inmd:items-start">
+                <section className="inmd:w-full inmd:max-w-[333px] px-3 insm:px-9 mx-auto flex flex-col items-center justify-center inmd:items-start">
                     <Icon.Logo width={onDesktop ? 666 : 111} height={0} />
                 </section>
-                <section className="inmd:w-full inmd:max-w-[333px] px-3 mr-auto [@media(max-width:1666px)]:mx-auto flex flex-col items-end justify-center gap-16 inmd:gap-6">
+                <section className="inmd:w-full inmd:max-w-[333px] px-3 insm:px-9 mr-auto [@media(max-width:1666px)]:mx-auto flex flex-col items-end justify-center gap-16 inmd:gap-6">
                     <header className="w-full">
                         <h1 className="font-extrabold text-7xl inlg:text-6xl inmd:text-5xl">
                             NoteHub
@@ -21,7 +21,7 @@ export const Welcome = (props: React.HTMLAttributes<HTMLElement>) => {
                             Organize, classifique e encontre.
                         </h2>
                     </header>
-                    <div className="w-full flex flex-col gap-12 inmd:gap-6">
+                    <div className="w-full flex flex-col gap-12 inmd:gap-6 inmd:items-center">
                         <section className="flex flex-col gap-4">
                             <header className="w-fit flex items-center gap-3">
                                 <h3 className="font-medium text-xl">Conecte-se</h3>

--- a/src/app/(pages)/help/items.tsx
+++ b/src/app/(pages)/help/items.tsx
@@ -149,6 +149,21 @@ export const items: Items[] = [
         )
     },
     {
+        id: 'subscriptions',
+        keywords: ["subscriptions", "inscrição", "inscrições", "inscrito", "tópico", "email", "notificações", "notificacoes"],
+        question: 'Inscrição',
+        answer: (
+            <>
+                Ao se inscrever em um tópico, você passará a receber atualizações por e-mail sobre o que for mais relevante para você.
+                <br /><br />
+                Essas atualizações são importantes para que você acompanhe novidades e melhorias do serviço.
+                Recomendamos que mantenha suas inscrições ativas, mas você pode cancelá-las a qualquer momento.
+                <br /><br />
+                Não enviamos spam nem e-mails promocionais — apenas informações úteis e relacionadas aos tópicos escolhidos.
+            </>
+        )
+    },
+    {
         id: 'report',
         keywords: ["repots", "denúncias", "denuncias", "avisar", "suporte"],
         question: 'Denúncia',

--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -16,6 +16,7 @@ import { UserNotificationsProvider } from "@/data/contexts/UserNotificationsCont
 import { UserPreferencesProvider } from "@/data/contexts/UserPreferencesContext";
 import { UserProvider } from "@/data/contexts/UserContext";
 import { UserStoreProvider } from "@/data/contexts/UserStoreContext";
+import { UserSubscriptionsProvider } from "@/data/contexts/UserSubscriptionsContext";
 import { UserTagsProvider } from "@/data/contexts/UserTagsContext";
 
 const UserProviders = ({ children }: { children: React.ReactNode }) => {
@@ -29,11 +30,13 @@ const UserProviders = ({ children }: { children: React.ReactNode }) => {
                             <UserFlamesProvider>
                                 <UserTagsProvider>
                                     <UserHistoryProvider>
-                                        <UserProvider>
-                                            <UserNotificationsProvider>
-                                                {children}
-                                            </UserNotificationsProvider>
-                                        </UserProvider>
+                                        <UserSubscriptionsProvider>
+                                            <UserProvider>
+                                                <UserNotificationsProvider>
+                                                    {children}
+                                                </UserNotificationsProvider>
+                                            </UserProvider>
+                                        </UserSubscriptionsProvider>
                                     </UserHistoryProvider>
                                 </UserTagsProvider>
                             </UserFlamesProvider>
@@ -62,14 +65,11 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
                 </ProgressBarProvider>
             </ScreenWidthProvider>
         </ScreenProvider>
-
     )
 }
 
 const layout = (props: any) => {
-
     const { Desktop, Mobile } = Device;
-
     return (
         <Providers>
             <Component.ProgressBar />

--- a/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/elements/Subscription.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/elements/Subscription.tsx
@@ -1,0 +1,64 @@
+import { clsx } from "clsx";
+import { Icon } from "@/components/icons";
+import { Subscription as Sub } from "@/core";
+import { useServices, useSubscriptions, useUser } from "@/data/hooks";
+import { useTransition } from "react";
+
+interface SubscriptionProps extends React.LiHTMLAttributes<HTMLLIElement> {
+    sub: Sub
+    name: string;
+}
+
+export const Subscription = ({ sub, name, ...rest }: SubscriptionProps) => {
+
+    const { userService: { enableSubscription, disableSubscription } } = useServices();
+
+    const { token } = useUser();
+    const { subscriptions, setSubscriptions } = useSubscriptions();
+    const [isPending, startTransition] = useTransition();
+
+    const isAllowed = subscriptions.includes(sub);
+
+    const handleClick = (): void => startTransition(async (): Promise<void> => {
+        if (token) {
+            if (isAllowed) {
+                await disableSubscription(token.access_token, sub);
+                return setSubscriptions(subscriptions.filter(s => s !== sub));
+            } else {
+                await enableSubscription(token.access_token, sub);
+                return setSubscriptions([...subscriptions, sub]);
+            }
+        }
+        return;
+    })
+
+    return (
+        <li className="relative px-4 py-3 flex items-center justify-between" {...rest}>
+            {isPending &&
+                <div
+                    role="status"
+                    className="cursor-wait
+                    z-10 absolute inset-0 rounded-full
+                    flex items-center justify-center
+                    dark:bg-middark/75 bg-midlight/75"
+                >
+                    <Icon.Dots />
+                </div>
+            }
+            <p>{name}</p>
+            <button
+                onClick={handleClick}
+                className={clsx(
+                    'relative w-[48px] h-[24px] rounded-full border-2',
+                    'after:absolute after:top-0 after:left-0 after:w-[50%] after:h-full after:rounded-full after:dark:bg-darker after:bg-lighter',
+                    isAllowed ? 'after:translate-x-full' : 'after:translate-x-0',
+                    isAllowed
+                        ? 'dark:border-lighter border-darker dark:bg-lighter bg-darker'
+                        : 'dark:border-middark border-midlight dark:bg-middark bg-midlight',
+                    'transition-all duration-300 after:transition-all after:duration-300',
+                )}
+            />
+        </li>
+    )
+
+}

--- a/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/elements/index.ts
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/elements/index.ts
@@ -1,0 +1,1 @@
+export { Subscription } from './Subscription';

--- a/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/subscriptions/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Header } from "../../../Header";
+import { scrollTo } from "@/core";
+import { Subscription } from "./elements";
+import { useUser } from "@/data/hooks";
+import Link from "next/link";
+
+const Page = () => {
+
+    const { user } = useUser();
+
+    if (user) return (
+        <section>
+            <Header goBack="/settings/account" title="Inscrições" />
+            <section className="mt-6 flex flex-col gap-6">
+                <ul>
+                    <Subscription sub="Maintenance" name="Manutenção" />
+                    <Subscription sub="Release" name="Atualizações" />
+                </ul>
+                <p className="font-medium text-sm dark:text-midlight/60 text-middark/60">
+                    Ao estar inscrito em um tópico, você passará a receber atualizações por e-mail sobre o que é mais relevante para você.
+                    <span className="ml-1 text-secondary hover:underline">
+                        <Link href="/help" onClickCapture={scrollTo('subscriptions')}>Saiba mais</Link>
+                    </span>
+                </p>
+            </section>
+        </section>
+    )
+
+}
+
+export default Page;

--- a/src/app/(pages)/settings/(pages)/account/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Header } from "../Header";
-import { IconCancel, IconEye, IconKey, IconLogout, IconMail, IconUser, IconUsers } from "@tabler/icons-react";
+import { IconBellRingingFilled, IconCancel, IconEye, IconKey, IconLogout, IconMail, IconUser, IconUsers } from "@tabler/icons-react";
 import { Link } from "./Link";
 import { useScreen, useUser } from "@/data/hooks";
 
@@ -15,19 +15,20 @@ const Page = () => {
             <Header goBack="/settings" title="Conta" />
             <section>
                 <ul className="mt-6">
-                    <Link href={"/settings/account/info"} icon={IconUser}>Informações</Link>
-                    <Link href={"/settings/account/visibility"} icon={IconEye}>Alterar visibilidade</Link>
-                    <Link href={"/settings/account/email"} icon={IconMail}>Alterar email</Link>
+                    <Link href="/settings/account/subscriptions" icon={IconBellRingingFilled}>Inscrições</Link>
+                    <Link href="/settings/account/info" icon={IconUser}>Informações</Link>
+                    <Link href="/settings/account/visibility" icon={IconEye}>Alterar visibilidade</Link>
+                    <Link href="/settings/account/email" icon={IconMail}>Alterar email</Link>
                     {user.host === "NoteHub" &&
                         <>
-                            <Link href={"/settings/account/password"} icon={IconKey}>Alterar senha</Link>
+                            <Link href="/settings/account/password" icon={IconKey}>Alterar senha</Link>
                         </>
                     }
-                    <Link href={"/settings/account/delete"} icon={IconCancel}>Deletar conta</Link>
+                    <Link href="/settings/account/delete" icon={IconCancel}>Deletar conta</Link>
                     {onMobile &&
                         <>
-                            <Link href={"/signin"} icon={IconUsers}>Mudar de conta</Link>
-                            <Link onClick={() => clearUser()} href={"/"} icon={IconLogout}>Sair</Link>
+                            <Link href="/signin" icon={IconUsers}>Mudar de conta</Link>
+                            <Link onClick={() => clearUser()} href="/" icon={IconLogout}>Sair</Link>
                         </>
                     }
                 </ul>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from './models';
 export * from './schemas';
+export * from './types';
 export * from './utils';

--- a/src/core/types/Subscription.ts
+++ b/src/core/types/Subscription.ts
@@ -1,0 +1,1 @@
+export type Subscription = 'Maintenance' | 'Release';

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Subscription';

--- a/src/data/contexts/UserSubscriptionsContext.tsx
+++ b/src/data/contexts/UserSubscriptionsContext.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { createContext, useCallback, useMemo, useState } from "react";
+import { Subscription } from "@/core";
+
+export interface UserSubscriptionsProps {
+    subscriptions: Subscription[];
+    setSubscriptions: (subscriptions: Subscription[]) => void;
+    clearSubscriptions: () => void;
+}
+
+const UserSubscriptionsContext = createContext<UserSubscriptionsProps>({} as any);
+
+export const UserSubscriptionsProvider = (props: any) => {
+
+    const initialState = useMemo(() => ({
+        subscriptions: [] as Subscription[]
+    }), [])
+
+    const [state, setState] = useState(initialState);
+
+    const setter = useCallback((subscriptions: Subscription[] | []): void => {
+        return setState({ subscriptions: subscriptions });
+    }, [])
+
+    const clear = useCallback(() => { setState(initialState) }, [initialState]);
+
+    return (
+        <UserSubscriptionsContext.Provider value={{
+            subscriptions: state.subscriptions,
+            setSubscriptions: setter,
+            clearSubscriptions: clear
+        }}>
+            {props.children}
+        </UserSubscriptionsContext.Provider>
+    )
+
+}
+
+export default UserSubscriptionsContext;

--- a/src/data/hooks/index.ts
+++ b/src/data/hooks/index.ts
@@ -7,6 +7,7 @@ export * from './useNotifications';
 export * from './useFollowing';
 export * from './useNotes';
 export * from './useTags';
+export * from './useSubscriptions';
 export * from './useProgress';
 export * from './useLoading';
 export * from './useScreen';

--- a/src/data/hooks/useSubscriptions.ts
+++ b/src/data/hooks/useSubscriptions.ts
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import UserSubscriptionsContext from "../contexts/UserSubscriptionsContext";
+
+export const useSubscriptions = () => useContext(UserSubscriptionsContext);

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -1,5 +1,5 @@
 import { AuthService } from '../auth';
-import { CreateUserFormData, Page, LowDetailUser, Notification, EditUserFormData, EmailChangeFormData, PasswordUpdateFormData, DeleteUserFormData } from '@/core';
+import { CreateUserFormData, Page, LowDetailUser, Notification, EditUserFormData, EmailChangeFormData, PasswordUpdateFormData, DeleteUserFormData, Subscription } from '@/core';
 import { useAPI } from '@/data/hooks';
 import { useCallback } from 'react';
 
@@ -136,6 +136,33 @@ export const UserService = () => {
         }
     }, [httpGet])
 
+    const getUserSubscriptions = useCallback(async (token: string): Promise<Subscription[]> => {
+        const endpoint: string = '/users/subscriptions';
+        try {
+            return await httpGet(endpoint, { useToken: token });
+        } catch (error: any) {
+            return handleExpiredToken(error, (newToken) => httpGet(endpoint, { useToken: newToken }));
+        }
+    }, [httpGet, handleExpiredToken])
+
+    const enableSubscription = useCallback(async (token: string, subscription: Subscription): Promise<void> => {
+        const endpoint = `/users/subscriptions/${subscription}`;
+        try {
+            return await httpPost(endpoint, undefined, { useToken: token });
+        } catch (error) {
+            return handleExpiredToken(error, (newToken) => httpPost(endpoint, undefined, { useToken: newToken }));
+        }
+    }, [httpPost, handleExpiredToken])
+
+    const disableSubscription = useCallback(async (token: string, subscription: Subscription): Promise<void> => {
+        const endpoint = `/users/subscriptions/${subscription}`;
+        try {
+            return await httpDelete(endpoint, undefined, { useToken: token });
+        } catch (error) {
+            return handleExpiredToken(error, (newToken) => httpDelete(endpoint, undefined, { useToken: newToken }));
+        }
+    }, [httpDelete, handleExpiredToken])
+
     const deleteUser = useCallback(async (token: string, data: DeleteUserFormData) => {
         const endpoint = '/users/delete';
         try {
@@ -160,6 +187,9 @@ export const UserService = () => {
         searchUserFollowers,
         getUserNotifications,
         searchUsers,
+        getUserSubscriptions,
+        enableSubscription,
+        disableSubscription,
         deleteUser
     }
 

--- a/src/shared/releases/releases.ts
+++ b/src/shared/releases/releases.ts
@@ -17,6 +17,26 @@ export interface Release {
 
 export const releases: Release[] = [
     {
+        version: 'v1.7',
+        date: '8/10/25 14:45',
+        title: 'Outubro 8, 2025',
+        summary: 'Inscrições de usuários e notificações por e-mail baseadas em tópicos',
+        entries: [
+            {
+                type: 'feat',
+                pr: 5,
+                hash: '2c76f18eec1aa1871a7a61998d393f9520f620cb',
+                desc: 'Adicionada coleção de inscrições aos usuários.'
+            },
+            {
+                type: 'feat',
+                pr: 5,
+                hash: '2c76f18eec1aa1871a7a61998d393f9520f620cb',
+                desc: 'Implementado suporte para ativar ou remover inscrições de tópicos.'
+            }
+        ]
+    },
+    {
         version: 'v1.6.1',
         date: '29/09/25 10:56',
         title: 'Setembro 29, 2025',


### PR DESCRIPTION
### Sumário

Este PR adiciona a interface de gerenciamento de inscrições por tópico (subscriptions) no cliente, além de hooks/contexts para consumo desses endpoints e atualiza a versão do app.

### Alterações

- `package.json`, `README.md` e `/changelog` atualizados para a release **1.7**;
- Página e componentes de gerenciamento de inscrições adicionados;
- Criado context e hook para gerenciar inscrições no cliente;
- Serviço de usuário atualizado para suportar ações de habilitar/desabilitar inscrições;
- Atualizada seção de ajuda para incluir orientações sobre inscrições;

### Motivação

Permitir que o usuário ative ou desative notificações por tópico diretamente na interface, melhorando a controlabilidade e a experiência do usuário ao receber comunicados específicos (ex.: novidades, avisos).

### Teste manual

1. Rode a aplicação;
2. Crie um novo usuário, ative-o e conecte-se;
3. Acesse a rota `/settings/account/subscriptions` e verifique a lista de tópicos disponíveis;
4. Ative e desative uma inscrição e confirme que o estado é persistido (após reload ou via inspeção de rede se aplicar API real/mocked);
5. Confira a seção de ajuda atualizada contendo instruções sobre como funcionam as inscrições.

### Checklist

- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes

- *Nenhuma*