### PR TITLE
feat(user): implement gif support to avatar for sponsors users

### DIFF
--- a/src/components/Photo.tsx
+++ b/src/components/Photo.tsx
@@ -22,7 +22,7 @@ export const Photo = forwardRef<HTMLImageElement, PhotoProps>((props, ref) => {
                 width={size}
                 height={size}
                 alt={`Avatar de ${user?.username ?? 'ex usuário'}`}
-                className="w-full h-full object-cover dark:bg-darker bg-lighter"
+                className="w-full h-full object-cover object-center dark:bg-darker bg-lighter"
             />
             <figcaption className="sr-only">{user?.display_name ?? 'ex usuário'}</figcaption>
         </figure>

--- a/src/components/PicturePortal.tsx
+++ b/src/components/PicturePortal.tsx
@@ -24,6 +24,7 @@ export const PicturePortal = forwardRef<HTMLImageElement, PicturePortalProps>(({
                         alt={`Avatar de ${user.username}`}
                         width={size}
                         height={size}
+                        className="w-full h-full object-cover object-center"
                     />
                 </figure>
             }

--- a/src/components/forms/user/update/elements/AvatarError.tsx
+++ b/src/components/forms/user/update/elements/AvatarError.tsx
@@ -1,0 +1,23 @@
+import { editUserFormSchema } from "@/core";
+import { useFormContext } from "react-hook-form";
+
+interface AvatarErrorProps extends React.HTMLAttributes<HTMLSpanElement> {
+    field: keyof typeof editUserFormSchema.shape;
+}
+
+export const AvatarError = ({ field, ...rest }: AvatarErrorProps) => {
+
+    const { formState: { errors } } = useFormContext();
+
+    const error = errors[field]?.message;
+
+    if (error) return (
+        <span
+            className="font-medium text-sm text-red-500"
+            {...rest}
+        >
+            {error.toString()}
+        </span>
+    )
+
+}

--- a/src/components/forms/user/update/elements/Banner.tsx
+++ b/src/components/forms/user/update/elements/Banner.tsx
@@ -16,7 +16,7 @@ interface BannerProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps) => {
 
-    const { setValue } = useFormContext<EditUserFormData>();
+    const { setValue, setError } = useFormContext<EditUserFormData>();
 
     const triggerRef = useRef<HTMLInputElement>(null);
     const closeRef = useRef<HTMLButtonElement>(null);
@@ -31,11 +31,13 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
     const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
         const file = e.target.files?.[0];
         if (file) {
+            setError('avatar', {});
+            if (file.type.endsWith('gif')) return setError('avatar', { message: 'GIFs são proibidos como banner.' });
             const preview = URL.createObjectURL(file);
             setPreview(preview);
         }
         if (triggerRef.current) triggerRef.current.value = '';
-    }, [])
+    }, [setError])
 
     const handleApplyClick = useCallback(async (): Promise<string | void> => {
         if (!triggerRef.current || !cropperRef.current) return;
@@ -59,6 +61,7 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
                 <div className="center flex items-center gap-3">
                     <Upload
                         ref={triggerRef}
+                        user={user}
                         name="banner"
                         handleFileChange={handleFileChange}
                         isBlocked={user.blocked}

--- a/src/components/forms/user/update/elements/Upload.tsx
+++ b/src/components/forms/user/update/elements/Upload.tsx
@@ -1,15 +1,17 @@
 import { ChangeEvent, forwardRef, InputHTMLAttributes } from "react";
 import { clsx } from "clsx";
-import { editUserFormSchema } from "@/core";
+import { editUserFormSchema, User } from "@/core";
 import { IconCameraPlus, IconForbid } from "@tabler/icons-react";
 
 interface UploadProps extends InputHTMLAttributes<HTMLInputElement> {
+    user: User;
+    allowGif?: boolean
     name: keyof typeof editUserFormSchema.shape;
     handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void;
     isBlocked: boolean;
 }
 
-export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleFileChange, isBlocked, className, ...rest }, ref) => {
+export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ user, allowGif, name, handleFileChange, isBlocked, className, ...rest }, ref) => {
 
     return (
         <>
@@ -19,7 +21,7 @@ export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ name, handleF
                 id={name}
                 ref={ref}
                 type="file"
-                accept="image/*"
+                accept={user.sponsor && allowGif ? "image/png, image/jpeg, image/gif" : "image/png, image/jpeg"}
                 className="hidden"
                 onChange={handleFileChange}
                 {...rest}

--- a/src/components/forms/user/update/elements/index.tsx
+++ b/src/components/forms/user/update/elements/index.tsx
@@ -1,6 +1,7 @@
 import { Header } from "./Header";
 import { Main } from "./Main";
 import { Banner } from "./Banner";
+import { AvatarError } from "./AvatarError";
 import { Avatar } from "./Avatar";
 import { Privacy } from "./Privacy";
 import { Dropdown } from "./Dropdown";
@@ -12,4 +13,4 @@ import { Counter } from "./Counter";
 import { Error } from "./Error";
 import { Link } from "./Link";
 
-export const Element = { Header, Main, Privacy, Dropdown, Banner, Avatar, Field, Label, Input, Textarea, Counter, Error, Link };
+export const Element = { Header, Main, Privacy, Dropdown, Banner, AvatarError, Avatar, Field, Label, Input, Textarea, Counter, Error, Link };

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -123,6 +123,7 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     </Element.Banner>
                     <Element.Privacy />
                     <div className="flex flex-col gap-6 px-4">
+                        <Element.AvatarError field="avatar" />
                         <Element.Field>
                             <Element.Input name="username" defaultValue={user.username} type="text" required />
                             <Element.Label htmlFor="username" labelFor="Usuário" />

--- a/src/components/templates/Modal.tsx
+++ b/src/components/templates/Modal.tsx
@@ -27,8 +27,11 @@ export const Modal = ({ className, triggerRef, closeRef, applyRef, onOpen, onClo
     }, [onClose])
 
     const handleChangeOnTrigger = useCallback((): void => {
+        const el = triggerRef.current;
+        if (el && el.files && el.files.length < 1) return;
+        if (el && el.files && el.files[0].type.endsWith('gif')) return;
         return handleOpenModal();
-    }, [handleOpenModal])
+    }, [handleOpenModal, triggerRef])
 
     const handleClickOnClose = useCallback((e: MouseEvent): void => {
         if (closeRef && closeRef.current?.contains(e.target as HTMLButtonElement)) {

--- a/src/supabase/storage/client.ts
+++ b/src/supabase/storage/client.ts
@@ -4,9 +4,9 @@ import { StoreProps, UploadProps } from "./types";
 import { v4 as uuidv4 } from "uuid";
 import imageCompression from 'browser-image-compression';
 
-export const uploadImage = async ({ file, bucket, folder, username }: UploadProps): Promise<string> => {
-    const path = `${folder}/${username}/${uuidv4()}.png`;
-    file = await imageCompression(file, { maxSizeMB: 1, })
+const uploadImage = async ({ file, bucket, folder, username }: UploadProps): Promise<string> => {
+    file = file.type === 'image/png' ? await imageCompression(file, { maxSizeMB: 1, }) : file;
+    const path = `${folder}/${username}/${uuidv4()}${file.type === 'image/png' ? '.png' : '.gif'}`;
     const { storage } = createSupabaseClient();
     const { data } = await storage.from(bucket).upload(path, file);
     return `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/${bucket}/${data!.path}`


### PR DESCRIPTION
### Sumário

Este PR implementa o suporte a avatares animados (GIFs) exclusivamente para usuários patrocinadores (sponsors). Também ajusta o fluxo de upload.

### Alterações

* Adicionada lógica condicional no componente `<Upload />` para incluir o formato `image/gif` no atributo `accept` apenas se o usuário for patrocinador (`user.sponsor`).
* Implementada validação de regra de negócio na função `handleFileChange` para bloquear GIFs para usuários não patrocinadores e para impor um limite de tamanho (12MB).
* Fluxo de edição (Cropper) foi **ignorado** para GIFs, garantindo que a animação seja preservada.
* Componentes de *upload* (`Avatar.tsx`, `Banner.tsx`, `Upload.tsx`) atualizados com a nova prop `allowGif`.
* Lógica de *storage* (`src/supabase/storage/client.ts`) atualizada para salvar o arquivo com a extensão correta (`.gif` ou `.png`/`.jpg`).

### Motivação

Oferecer um recurso visual exclusivo para usuários patrocinadores (avatares animados), aumentando o valor percebido do patrocínio e enriquecendo a experiência do perfil do usuário.

### Teste Manual

1.  Rode a aplicação;
2.  **Teste 1 (Patrocinador - Avatar):**
    * Conecte-se com um usuário que tenha `user.sponsor = true`.
    * Tente fazer o *upload* de um arquivo GIF válido (abaixo de 12MB).
    * Verifique se o GIF é exibido no perfil e a animação é mantida.
3.  **Teste 2 (Patrocinador - Restrição de Tamanho):**
    * Tente fazer o *upload* de um arquivo GIF **acima de 12MB** e confirme se a mensagem de erro é exibida.
4.  **Teste 3 (Comum - Avatar):**
    * Conecte-se com um usuário que tenha `user.sponsor = false`.
    * Tente fazer o *upload* de um arquivo GIF. Confirme se o sistema **bloqueia** o *upload* e exibe a mensagem de erro (e se o `accept` do input não o sugere).
5.  **Teste 4 (Banner):**
    * Tente fazer o *upload* de um arquivo GIF para a imagem de banner (onde a prop `allowGif` é `false`). O sistema **não deve** aceitar, mesmo para um patrocinador.
6.  **Teste 5 (Imagem Estática):**
    * Faça o *upload* de uma imagem PNG/JPEG e verifique se o fluxo do *cropper* **continua funcionando** normalmente.

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes

- *Nenhuma*