### PR TITLE
fix(upload): resolve null banner upload and centralize validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v2.0">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-2.0-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-client/releases/tag/v2.0.1">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-2.0.1-7c3aed">
   </a>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notehub",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notehub",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@react-oauth/google": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notehub",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/forms/user/update/elements/Avatar.tsx
+++ b/src/components/forms/user/update/elements/Avatar.tsx
@@ -35,7 +35,6 @@ export const Avatar = ({ user, onModalOpen, onModalClose, ...props }: AvatarProp
         if (file) {
             setError('avatar', {});
             if (file.type.endsWith('gif')) {
-                if (!user.sponsor) return setError('avatar', { message: 'GIFs apenas para patrocinadores.' });
                 if (file.size > 12 * 1024 * 1024) return setError('avatar', { message: 'GIFs não podem ultrapassar 12MB.' });
                 const gif = URL.createObjectURL(file);
                 setUrl(gif);
@@ -45,7 +44,7 @@ export const Avatar = ({ user, onModalOpen, onModalClose, ...props }: AvatarProp
             setPreview(preview);
         }
         if (triggerRef.current) triggerRef.current.value = '';
-    }, [setError, setValue, user.sponsor])
+    }, [setError, setValue])
 
     const handleApplyClick = useCallback(async (): Promise<string | void> => {
         if (!triggerRef.current || !cropperRef.current) return;

--- a/src/components/forms/user/update/elements/Banner.tsx
+++ b/src/components/forms/user/update/elements/Banner.tsx
@@ -31,8 +31,7 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
     const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
         const file = e.target.files?.[0];
         if (file) {
-            setError('avatar', {});
-            if (file.type.endsWith('gif')) return setError('avatar', { message: 'GIFs são proibidos como banner.' });
+            setError('banner', {});
             const preview = URL.createObjectURL(file);
             setPreview(preview);
         }
@@ -51,6 +50,7 @@ export const Banner = ({ user, onModalOpen, onModalClose, ...rest }: BannerProps
     const handleRemovalClick = (): void => {
         setUrl('/imgs/banner.png');
         setValue('banner', null);
+        setError('banner', {});
         return;
     }
 

--- a/src/components/forms/user/update/elements/UploadError.tsx
+++ b/src/components/forms/user/update/elements/UploadError.tsx
@@ -1,15 +1,17 @@
 import { editUserFormSchema } from "@/core";
 import { useFormContext } from "react-hook-form";
 
-interface AvatarErrorProps extends React.HTMLAttributes<HTMLSpanElement> {
-    field: keyof typeof editUserFormSchema.shape;
+interface UploadErrorProps extends React.HTMLAttributes<HTMLSpanElement> {
+    fields: Array<keyof typeof editUserFormSchema.shape>;
 }
 
-export const AvatarError = ({ field, ...rest }: AvatarErrorProps) => {
+export const UploadError = ({ fields, ...rest }: UploadErrorProps) => {
 
     const { formState: { errors } } = useFormContext();
 
-    const error = errors[field]?.message;
+    const error = fields
+        .map(field => errors[field]?.message)
+        .find(msg => msg !== undefined);
 
     if (error) return (
         <span

--- a/src/components/forms/user/update/elements/index.tsx
+++ b/src/components/forms/user/update/elements/index.tsx
@@ -1,7 +1,7 @@
 import { Header } from "./Header";
 import { Main } from "./Main";
 import { Banner } from "./Banner";
-import { AvatarError } from "./AvatarError";
+import { UploadError } from "./UploadError";
 import { Avatar } from "./Avatar";
 import { Privacy } from "./Privacy";
 import { Dropdown } from "./Dropdown";
@@ -13,4 +13,4 @@ import { Counter } from "./Counter";
 import { Error } from "./Error";
 import { Link } from "./Link";
 
-export const Element = { Header, Main, Privacy, Dropdown, Banner, AvatarError, Avatar, Field, Label, Input, Textarea, Counter, Error, Link };
+export const Element = { Header, Main, Privacy, Dropdown, Banner, UploadError, Avatar, Field, Label, Input, Textarea, Counter, Error, Link };

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -44,10 +44,10 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
 
                 const [avatarPromise, bannerPromise] = [
                     shouldUpdateAvatar
-                        ? storeImg({ folder: "avatars", username: data.username, blobUrl: data.avatar! })
+                        ? storeImg({ folder: "avatars", username: data.username, blobUrl: data.avatar })
                         : Promise.resolve(user.avatar),
                     shouldUpdateBanner
-                        ? storeImg({ folder: "banners", username: data.username, blobUrl: data.banner! })
+                        ? storeImg({ folder: "banners", username: data.username, blobUrl: data.banner })
                         : Promise.resolve(user.banner)
                 ]
 

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -123,7 +123,7 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     </Element.Banner>
                     <Element.Privacy />
                     <div className="flex flex-col gap-6 px-4">
-                        <Element.AvatarError field="avatar" />
+                        <Element.UploadError fields={['avatar', 'banner']} />
                         <Element.Field>
                             <Element.Input name="username" defaultValue={user.username} type="text" required />
                             <Element.Label htmlFor="username" labelFor="Usuário" />

--- a/src/shared/releases/releases.ts
+++ b/src/shared/releases/releases.ts
@@ -17,6 +17,20 @@ export interface Release {
 
 export const releases: Release[] = [
     {
+        version: 'v2.0.1',
+        date: '17/12/25 11:24',
+        title: '17 de Dezembro de 2025',
+        summary: 'Correção de segurança e restrição de cosméticos.',
+        entries: [
+            {
+                type: 'fix',
+                pr: 10,
+                hash: '19d3b3446a3a9803742be8330b36530dd3c912bc',
+                desc: 'Corrigida vulnerabilidade na API que permitia o uso de avatares animados (.gif) por usuários sem assinatura de patrocinador.'
+            }
+        ]
+    },
+    {
         version: 'v2.0',
         date: '12/12/25 14:11',
         title: 'Dezembro 12, 2025',

--- a/src/supabase/storage/client.ts
+++ b/src/supabase/storage/client.ts
@@ -28,12 +28,15 @@ export const deleteImage = async (url: string) => {
 
 }
 
-export const storeImg = async ({ folder, username, blobUrl }: StoreProps): Promise<string> => {
-    const file = await convertBlobUrlToFile(blobUrl);
-    return await uploadImage({
-        file: file,
-        bucket: "images",
-        folder: folder,
-        username: username
-    })
+export const storeImg = async ({ folder, username, blobUrl }: StoreProps): Promise<string | void> => {
+    if (blobUrl) {
+        const file = await convertBlobUrlToFile(blobUrl);
+        return await uploadImage({
+            file: file,
+            bucket: "images",
+            folder: folder,
+            username: username
+        })
+    }
+    return;
 }

--- a/src/supabase/storage/types.ts
+++ b/src/supabase/storage/types.ts
@@ -8,7 +8,7 @@ export type UploadProps = {
 }
 
 export type StoreProps = {
-    blobUrl: string;
+    blobUrl: string | null;
     folder: "avatars" | "banners";
     username: User["username"];
 }


### PR DESCRIPTION
### Sumário

Este PR corrige um bug crítico onde banners nulos geravam arquivos .gif corrompidos, e refatora o sistema de validação de imagens para centralizar a lógica no backend, melhorando a consistência e manutenibilidade do código.

### Alterações

* `package.json`, `README.md` e `/changelog` atualizados para a release **2.0.1**;
* Removidas validações manuais Zod em favor de respostas diretas da API.
* Banner nulo no formulário de atualização de usuário não mais gera arquivo falho .gif.

### Motivação

A centralização no backend garante uma única fonte de verdade para regras de validação, enquanto o tratamento adequado de valores nulos previne corrupção de dados.

### Teste Manual

* Remova a imagem de capa de usuário -> Deve ser sucesso;
* Faça o upload de uma imagem .gif em um não patrocinador -> Deve manter os mesmo erros anteriores;


### Checklist

- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados

## Breaking Changes

* *Nenhuma* - atualização de patch que mantém compatibilidade com a versão anterior