### PR TITLE
fix(note): allow re-upload of same file after local changes

### DIFF
--- a/src/components/forms/note/new/elements/FileFieldset.tsx
+++ b/src/components/forms/note/new/elements/FileFieldset.tsx
@@ -31,6 +31,7 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (file) processFile(file);
+        return e.target.value = '';
     }
 
     const handleDrop = (e: React.DragEvent<HTMLFieldSetElement>) => {


### PR DESCRIPTION

### Sumário

Corrige bug onde o re-upload do mesmo arquivo via seletor nativo não atualizava o conteúdo quando o arquivo era modificado localmente entre uploads.

### Alterações

* Adicionado reset do valor do `input file` após processar o arquivo no handler `handleFileChange`.

### Motivação

O navegador não dispara o evento `onChange` quando o usuário seleciona um arquivo com o mesmo nome/caminho do anterior, resultando em conteúdo desatualizado. O método drag & drop não sofria desse problema pois trabalha diretamente com a API DataTransfer. Esta correção garante consistência entre ambos os métodos de upload.

### Teste Manual

1. Acesse a rota de criação de nota;
2. Crie um arquivo `test.txt` vazio localmente;
3. Faça upload via seletor de arquivo (clique no componente);
4. Edite o `test.txt` localmente, adicione conteúdo e salve;
5. Faça upload do mesmo arquivo novamente;
6. ✅ Verifique que o novo conteúdo foi carregado corretamente.


### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

## Breaking Changes

* *Nenhuma*