### PR TITLE
fix(search): reset page param when filters change

### DIFF
--- a/src/app/(pages)/search/elements/aside/Sorter.tsx
+++ b/src/app/(pages)/search/elements/aside/Sorter.tsx
@@ -18,6 +18,7 @@ export const Sorter = ({ sParam, values, icon: Icon, className, children, ...res
 
     const handleParamUpdate = useCallback(() => {
         const params = new URLSearchParams(sParams);
+        params.delete('page');
         params.set(sParam, values[0] ? values[0] : '');
         window.history.replaceState(null, '', `${pathname}?${params}`);
     }, [pathname, sParam, sParams, values])

--- a/src/app/(pages)/search/elements/header/Sorter.tsx
+++ b/src/app/(pages)/search/elements/header/Sorter.tsx
@@ -21,6 +21,7 @@ export const Sorter = ({ orderParam, sortParam, orderValues, sortValues, icon: I
 
     const handleParamUpdate = useCallback(() => {
         const params = new URLSearchParams(sParams);
+        params.delete('page');
         params.set(orderParam, orderValues[0] ? orderValues[0] : '');
         params.set(sortParam, sortValues[0] ? sortValues[0] : '');
         window.history.replaceState(null, '', `${pathname}?${params}`);


### PR DESCRIPTION
### Sumário

Este PR corrige o comportamento da rota `/search` ao trocar filtros de pesquisa, garantindo que o parâmetro de paginação (`page`) seja removido quando os parâmetros principais forem alterados.

### Alterações

* Removido o parâmetro `page` ao alterar filtros principais da pesquisa.

### Motivação

Ao trocar os filtros da rota `/search`, o parâmetro `page` era mantido indevidamente, o que podia resultar em páginas inválidas ou inconsistentes para o novo tipo de busca (ex: mudar de `users` para `tags` mantendo `page=2`).  
Esta correção garante uma experiência mais previsível e evita estados incorretos na navegação.

### Teste Manual

* Alterar qualquer filtro na rota `/search` enquanto estiver em uma página diferente da primeira e verificar que o parâmetro `page` é removido da URL.

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes

* *Nenhuma*