### PR TITLE
feat: add react query for data fetching and automatic cache management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "notehub",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notehub",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@react-oauth/google": "^0.12.1",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.1",
         "@tabler/icons-react": "^3.21.0",
+        "@tanstack/react-query": "^5.90.21",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.5.0",
         "browser-image-compression": "^2.0.2",
@@ -1415,6 +1416,32 @@
       },
       "peerDependencies": {
         "react": ">= 16"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tsparticles/basic": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.1",
     "@tabler/icons-react": "^3.21.0",
+    "@tanstack/react-query": "^5.90.21",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.5.0",
     "browser-image-compression": "^2.0.2",

--- a/src/app/(pages)/[username]/[id]/elements/comments/elements/header/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/comments/elements/header/index.tsx
@@ -7,11 +7,10 @@ import { useState } from "react";
 interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
     sort: "repliesCount,desc" | "createdAt,desc";
     note: Note;
-    setHasFetched: React.Dispatch<React.SetStateAction<boolean>>;
     setSort: React.Dispatch<React.SetStateAction<"repliesCount,desc" | "createdAt,desc">>;
 }
 
-export const Header = ({ sort, note, setSort, setHasFetched, ...rest }: HeaderProps) => {
+export const Header = ({ sort, note, setSort, ...rest }: HeaderProps) => {
 
     const { Title, Sorter } = Element;
 
@@ -26,7 +25,6 @@ export const Header = ({ sort, note, setSort, setHasFetched, ...rest }: HeaderPr
         if (sort === "repliesCount,desc") return;
         setSort("repliesCount,desc");
         setIsMenuOpen(false);
-        setHasFetched(false);
     }
 
     const sortByCreatedAt = (e: React.MouseEvent<HTMLLIElement>) => {
@@ -34,7 +32,6 @@ export const Header = ({ sort, note, setSort, setHasFetched, ...rest }: HeaderPr
         if (sort === "createdAt,desc") return;
         setSort("createdAt,desc");
         setIsMenuOpen(false);
-        setHasFetched(false);
     }
 
     return (

--- a/src/app/(pages)/[username]/[id]/elements/comments/elements/replies/loader/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/comments/elements/replies/loader/index.tsx
@@ -1,34 +1,35 @@
 import { clsx } from "clsx";
-import { Comment, Page, Reply, Token } from "@/core"
+import { Comment, Reply, Token } from "@/core"
 import { IconArrowForward } from "@tabler/icons-react";
 import { useServices } from "@/data/hooks";
-import { useTransition } from "react";
 
 interface LoadMoreProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     token: Token | null;
     isRepliesListOpen: boolean;
     comment: Comment;
-    page: Omit<Page<Reply>, 'content'>;
-    setPage: React.Dispatch<React.SetStateAction<Omit<Page<Reply>, 'content'>>>;
     setReplies: React.Dispatch<React.SetStateAction<Reply[]>>;
 }
 
-export const Loader = ({ token, isRepliesListOpen, comment, page, setPage, setReplies, ...rest }: LoadMoreProps) => {
+export const Loader = ({ token, isRepliesListOpen, comment, setReplies, ...rest }: LoadMoreProps) => {
 
-    const { replyService: { getReplies } } = useServices();
+    const { replyServiceQueries: { useGetReplies } } = useServices();
 
-    const [isPending, startTransition] = useTransition();
+    const accessToken = token ? token.access_token : null;
+    const { fetchNextPage, hasNextPage, isFetchingNextPage } = useGetReplies(accessToken, comment.id, false);
 
-    const handleClick = () => startTransition(async () => {
-        const accessToken = token ? token.access_token : null;
-        const { content, ...rest } = await getReplies(accessToken, comment.id, `page=${page.page + 1}`);
-        setReplies(prev => [...prev, ...content]);
-        setPage(rest);
-    })
+    const handleClick = () => {
+        fetchNextPage().then((result) => {
+            if (result.data) {
+                const lastPage = result.data.pages.at(-1);
+                const replies = lastPage ? lastPage.content : [];
+                setReplies(prev => [...prev, ...replies]);
+            }
+        })
+    }
 
-    if (isRepliesListOpen && !page.last) return (
+    if (isRepliesListOpen && hasNextPage) return (
         <button
-            disabled={isPending}
+            disabled={isFetchingNextPage}
             onClick={handleClick}
             className={clsx(
                 'disabled:cursor-wait',
@@ -44,5 +45,7 @@ export const Loader = ({ token, isRepliesListOpen, comment, page, setPage, setRe
             Carregar mais
         </button>
     )
+
+    return null;
 
 }

--- a/src/app/(pages)/[username]/[id]/elements/comments/elements/replies/update/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/comments/elements/replies/update/index.tsx
@@ -23,6 +23,7 @@ export const ReplyItem = ({ token, user, note, comment, reply, setReplies, setRe
                 token={token}
                 user={user}
                 note={note}
+                comment={comment}
                 reply={reply}
                 setReplies={setReplies}
                 setRepliesCount={setRepliesCount}

--- a/src/app/(pages)/[username]/[id]/elements/comments/elements/update/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/comments/elements/update/index.tsx
@@ -1,4 +1,4 @@
-import { Comment, Note, Page, Reply, Token, User } from "@/core";
+import { Comment, Note, Reply, Token, User } from "@/core";
 import { Form } from "@/components/forms";
 import { Loader, ReplyBox, ReplyItem } from "../replies";
 import { Skeleton } from "./skeleton";
@@ -17,7 +17,6 @@ interface CommentItemProps {
 export const CommentItem = ({ isSorting, token, user, note, comment, setNote, setComments }: CommentItemProps) => {
 
     const [repliesCount, setRepliesCount] = useState<number>(comment.replies_count ?? 0);
-    const [repliesPage, setRepliesPage] = useState<Omit<Page<Reply>, 'content'>>({} as Omit<Page<Reply>, 'content'>);
     const [replies, setReplies] = useState<Reply[]>([]);
     const [isReplying, setIsReplying] = useState<boolean>(false);
     const [isRepliesListOpen, setIsRepliesListOpen] = useState<boolean>(false);
@@ -35,7 +34,6 @@ export const CommentItem = ({ isSorting, token, user, note, comment, setNote, se
                 isRepliesListOpen={isRepliesListOpen}
                 setNote={setNote}
                 setComments={setComments}
-                setRepliesPage={setRepliesPage}
                 setReplies={setReplies}
                 setIsReplying={setIsReplying}
                 setIsRepliesListOpen={setIsRepliesListOpen}
@@ -70,8 +68,6 @@ export const CommentItem = ({ isSorting, token, user, note, comment, setNote, se
                 token={token}
                 isRepliesListOpen={isRepliesListOpen}
                 comment={comment}
-                page={repliesPage}
-                setPage={setRepliesPage}
                 setReplies={setReplies}
             />
         </>

--- a/src/app/(pages)/[username]/[id]/elements/comments/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/comments/index.tsx
@@ -1,6 +1,6 @@
-import { Comment, Note, Page, Token, User } from "@/core";
+import { Comment, Note, Token, User } from "@/core";
 import { Element } from "./elements";
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useServices } from "@/data/hooks";
 
 interface CommentsProps {
@@ -12,78 +12,47 @@ interface CommentsProps {
 
 export const Comments = ({ token, user, note, setNote }: CommentsProps) => {
 
-    const { commentService: { getComments } } = useServices();
+    const { commentServiceQueries: { useGetComments } } = useServices();
 
     const isFetching = useRef<boolean>(false);
-    const [hasFetched, setHasFetched] = useState<boolean>(false);
-    const [page, setPage] = useState<Omit<Page<Comment>, 'content'>>({} as Omit<Page<Comment>, 'content'>);
     const [comments, setComments] = useState<Comment[]>([]);
     const [sort, setSort] = useState<"repliesCount,desc" | "createdAt,desc">("repliesCount,desc");
-    const [isSorting, setIsSorting] = useState<boolean>(false);
 
-    const [isPending, startTransition] = useTransition();
-
-    const init = useCallback(async () => {
-        if (note.comments_count === 0 || isFetching.current || hasFetched) return;
-        setIsSorting(true);
-        startTransition(async () => {
-            try {
-                isFetching.current = true;
-                const accessToken = token ? token.access_token : null;
-                const { content, ...rest } = await getComments(accessToken, note.id, `sort=${sort}&page=0`);
-                setPage(rest);
-                setComments(content);
-            } catch (error) {
-                throw error;
-            } finally {
-                isFetching.current = false;
-                setIsSorting(false);
-                setHasFetched(true);
-            }
-        })
-    }, [getComments, hasFetched, note.comments_count, note.id, sort, token])
-
-    const handleScroll = useCallback(async () => {
-        if (note.comments_count === 0 || isFetching.current || page.last) return;
-        startTransition(async () => {
-            const scrollY = window.scrollY;
-            const windowHeight = window.innerHeight;
-            const docHeight = document.documentElement.scrollHeight;
-            if (scrollY + windowHeight >= docHeight - 1) {
-                try {
-                    isFetching.current = true;
-                    const accessToken = token ? token.access_token : null;
-                    const { content, ...rest } = await getComments(accessToken, note.id, `sort=${sort}&page=${page.page + 1}`);
-                    setPage(rest);
-                    setComments(prev => {
-                        const existingIds = new Set(prev.map(c => c.id));
-                        const newUniqueComments = content.filter(c => !existingIds.has(c.id));
-                        return [...prev, ...newUniqueComments];
-                    });
-                } catch (error) {
-                    throw error;
-                } finally {
-                    isFetching.current = false;
-                    setHasFetched(true);
-                }
-            }
-        })
-    }, [getComments, note.comments_count, note.id, page.last, page.page, sort, token])
+    const accessToken = token ? token.access_token : null;
+    const { data,
+        isLoading,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
+    } = useGetComments(accessToken, note.id, sort, true);
 
     useEffect(() => {
-        init();
+        if (data) setComments(data.pages.flatMap(p => p.content) ?? []);
+    }, [data])
+
+    const handleScroll = useCallback(() => {
+        if (!hasNextPage || isFetchingNextPage || isFetching.current) return;
+        const scrollY = window.scrollY;
+        const windowHeight = window.innerHeight;
+        const docHeight = document.documentElement.scrollHeight;
+        if (scrollY + windowHeight >= docHeight - 1) {
+            isFetching.current = true;
+            fetchNextPage().finally(() => isFetching.current = false);
+        }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+    useEffect(() => {
         window.addEventListener("scroll", handleScroll);
         return () => window.removeEventListener("scroll", handleScroll);
-    }, [handleScroll, hasFetched, init])
+    }, [handleScroll])
 
     const { Header, CommentBox, CommentItem, Footer } = Element;
 
-    return (
+    if (data) return (
         <>
             <Header
                 sort={sort}
                 note={note}
-                setHasFetched={setHasFetched}
                 setSort={setSort}
             />
             <CommentBox
@@ -97,7 +66,7 @@ export const Comments = ({ token, user, note, setNote }: CommentsProps) => {
                 {comments.map((comment) => (
                     <li key={comment.id}>
                         <CommentItem
-                            isSorting={isSorting}
+                            isSorting={isLoading}
                             token={token}
                             user={user}
                             note={note}
@@ -108,8 +77,10 @@ export const Comments = ({ token, user, note, setNote }: CommentsProps) => {
                     </li>
                 ))}
             </ul>
-            <Footer isPending={isPending} />
+            <Footer isPending={isFetchingNextPage} />
         </>
     )
+
+    return null;
 
 }

--- a/src/app/(pages)/[username]/[id]/page.tsx
+++ b/src/app/(pages)/[username]/[id]/page.tsx
@@ -7,118 +7,108 @@ import { IconEyeOff, IconLock, IconNotesOff } from "@tabler/icons-react";
 import { Section } from "../components/Section";
 import { Skeleton } from "./skeleton";
 import { Template } from "@/components/templates";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 import { UUID } from "crypto";
 
 const Page = () => {
 
-    const { noteService: { getNote } } = useServices();
+    const { noteServiceQueries: { useGetNote } } = useServices();
 
     const { isMounted, token, user } = useUser();
 
     const noteId = useParams<{ username: string; id: UUID }>().id;
 
+    const { data: response, isLoading } = useGetNote(token ? token.access_token : null, noteId, isMounted);
+
     const [note, setNote] = useState<Note | null>(null);
-    const [notCurrent, setNotCurrent] = useState<boolean>(false);
-    const [notMutual, setNotMutual] = useState<boolean>(false);
-    const [notFound, setNotFound] = useState<boolean>(false);
     const triggerRef = useRef<HTMLButtonElement>(null);
     const childRef = useRef<HTMLFormElement>(null);
     const closeRef = useRef<HTMLButtonElement>(null);
 
-    const init = useCallback(async () => {
-        const accessToken = token ? token.access_token : null;
-        try {
-            return setNote(await getNote(accessToken, noteId));
-        } catch (errors) {
-            if (Array.isArray(errors)) {
-                const { notCurrent, notMutual } = handleFieldErrorsMsg(errors);
-                console.log({
-                    notCurrent: notCurrent,
-                    notMutual: notMutual
-                })
-                setNotCurrent(notCurrent);
-                setNotMutual(notMutual);
-                return;
-            } else return setNotFound(true);
-        }
-    }, [getNote, noteId, token]);
-
     useEffect(() => {
-        if (isMounted) init();
-    }, [isMounted])
+        if (response && response.type === 'ok') setNote(response.data);
+    }, [response])
 
     const { Aside, Comments, Dialog } = Element;
 
-    if (notFound) return (
-        <Section className="p-6 flex items-center justify-center">
-            <Dialog
-                icon={IconNotesOff}
-                title="404"
-                desc="Nota não encontrada."
-            />
-        </Section>
-    )
+    if (isLoading) return <Skeleton />;
 
-    if (notCurrent) return (
-        <Section className="p-6 flex items-center justify-center">
-            <Dialog
-                icon={IconEyeOff}
-                title="Nota oculta"
-                desc="Nome auto explicativo."
-            />
-        </Section>
-    )
+    if (response) {
 
-    if (notMutual) return (
-        <Section className="p-6 flex items-center justify-center">
-            <Dialog
-                icon={IconLock}
-                title="Perfil privado"
-                desc="Necessário que ambos de vocês se sigam."
-            />
-        </Section>
-    )
+        if (response.type === 'notfound') return (
+            <Section className="p-6 flex items-center justify-center">
+                <Dialog
+                    icon={IconNotesOff}
+                    title="404"
+                    desc="Nota não encontrada."
+                />
+            </Section>
+        )
 
-    if (note) return (
-        <section className="max-w-[999px] w-full m-auto pb-64">
-            <section className="flex inlg:flex-col-reverse">
-                <Template.Portal blur="sm" triggerRef={triggerRef} childRef={childRef} closeRef={closeRef}>
-                    <Form.Note.Update
-                        ref={childRef}
-                        closeRef={closeRef}
+        if (response.type === 'forbidden') {
+            const { notCurrent, notMutual } = handleFieldErrorsMsg(response.data);
+            if (notCurrent) return (
+                <Section className="p-6 flex items-center justify-center">
+                    <Dialog
+                        icon={IconEyeOff}
+                        title="Nota oculta"
+                        desc="Nome auto explicativo."
+                    />
+                </Section>
+            )
+            if (notMutual) return (
+                <Section className="p-6 flex items-center justify-center">
+                    <Dialog
+                        icon={IconLock}
+                        title="Perfil privado"
+                        desc="Necessário que ambos de vocês se sigam."
+                    />
+                </Section>
+            )
+            return null;
+        }
+
+        if (note) return (
+            <section className="max-w-[999px] w-full m-auto pb-64">
+                <section className="flex inlg:flex-col-reverse">
+                    <Template.Portal blur="sm" triggerRef={triggerRef} childRef={childRef} closeRef={closeRef}>
+                        <Form.Note.Update
+                            ref={childRef}
+                            closeRef={closeRef}
+                            token={token}
+                            note={note}
+                            setNote={setNote}
+                        />
+                    </Template.Portal>
+                    <Form.Note.TextUpdate
                         token={token}
+                        note={note}
+                        author={note.user ? note.user.username : null}
+                        currentUser={user ? user.username : null}
+                    />
+                    <Aside
+                        triggerRef={triggerRef}
+                        note={note}
+                        author={note.user ? note.user.username : null}
+                        currentUser={user ? user.username : null}
+                    />
+                </section>
+                <section className="w-[72.5%] inlg:w-full inmd:px-2 py-2">
+                    <Comments
+                        token={token}
+                        user={user}
                         note={note}
                         setNote={setNote}
                     />
-                </Template.Portal>
-                <Form.Note.TextUpdate
-                    token={token}
-                    note={note}
-                    author={note.user ? note.user.username : null}
-                    currentUser={user ? user.username : null}
-                />
-                <Aside
-                    triggerRef={triggerRef}
-                    note={note}
-                    author={note.user ? note.user.username : null}
-                    currentUser={user ? user.username : null}
-                />
+                </section>
             </section>
-            <section className="w-[72.5%] inlg:w-full inmd:px-2 py-2">
-                <Comments
-                    token={token}
-                    user={user}
-                    note={note}
-                    setNote={setNote}
-                />
-            </section>
-        </section>
-    )
+        )
 
-    return <Skeleton />;
+    }
+
+    return null;
 
 }
 

--- a/src/app/(pages)/[username]/components/Header.tsx
+++ b/src/app/(pages)/[username]/components/Header.tsx
@@ -22,8 +22,8 @@ export const Header = () => {
     const { data: userData, isLoading: isUserLoading } = useGetUser(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
     const { data: historyData } = useGetUserDisplayNameHistory(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
 
-    const user = currentUser ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
-    const history = currentHistory ? currentHistory : historyData && historyData.type === 'ok' ? historyData.data : null;
+    const user = shouldSkipFetch ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
+    const history = shouldSkipFetch ? currentHistory : historyData && historyData.type === 'ok' ? historyData.data : null;
 
     if (shouldSkipHeader) return null;
 

--- a/src/app/(pages)/[username]/components/Header.tsx
+++ b/src/app/(pages)/[username]/components/Header.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import { Desktop } from "./desktop";
-import { LowDetailUser, User } from "@/core";
 import { Mobile } from "./mobile";
 import { Template } from "@/components/templates";
-import { useEffect, useRef, useState } from "react";
 import { useHistory, useScreen, useServices, useUser } from "@/data/hooks";
 import { useParams } from "next/navigation";
 
 export const Header = () => {
 
-    const { userService: { getUser, getUserDisplayNameHistory } } = useServices();
+    const { userServiceQueries: { useGetUser, useGetUserDisplayNameHistory } } = useServices();
 
     const params = useParams<{ username: string }>();
 
@@ -18,48 +16,28 @@ export const Header = () => {
     const { isMounted, user: currentUser } = useUser();
     const { history: currentHistory } = useHistory();
 
-    const [state, setState] = useState({
-        notFound: false,
-        user: null as User | null as LowDetailUser,
-        history: [] as string[]
-    })
-
-    const { notFound, user, history } = state;
-
     const shouldSkipHeader: boolean = params.username === "user";
+    const shouldSkipFetch: boolean = currentUser ? currentUser.username === params.username : false;
 
-    const isFetching = useRef<boolean>(false);
+    const { data: userData, isLoading: isUserLoading } = useGetUser(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
+    const { data: historyData } = useGetUserDisplayNameHistory(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
 
-    useEffect(() => {
-        const init = async () => {
-            if (shouldSkipHeader || isFetching.current) return;
-            if (currentUser && params.username === currentUser.username) {
-                return setState((prev) => ({ ...prev, user: currentUser, history: currentHistory }));
-            }
-            isFetching.current = true;
-            try {
-                const user = await getUser(params.username);
-                const history = await getUserDisplayNameHistory(params.username);
-                return setState((prev) => ({ ...prev, user: user, history: history }));
-            } catch {
-                return setState((prev) => ({ ...prev, notFound: true }));
-            } finally {
-                return isFetching.current = false;
-            }
-        }
-        if (isMounted) init();
-    }, [currentHistory, currentUser, getUser, getUserDisplayNameHistory, isMounted, params.username, shouldSkipHeader])
+    const user = currentUser ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
+    const history = currentHistory ? currentHistory : historyData && historyData.type === 'ok' ? historyData.data : null;
 
     if (shouldSkipHeader) return null;
 
-    if (notFound) return <Template.Forbidden />;
+    if (onDesktop && isUserLoading) return <Desktop.HeaderSkeleton />;
 
-    if (onDesktop && !user) return <Desktop.HeaderSkeleton />;
+    if (onMobile && isUserLoading) return <Mobile.HeaderSkeleton />;
 
-    if (onMobile && !user) return <Mobile.HeaderSkeleton />;
+    if (userData && userData.type === 'notfound') return <Template.Forbidden />
 
-    if (onDesktop && user) return <Desktop.Header user={user} history={history} />;
+    if (user && history) {
+        if (onDesktop) return <Desktop.Header user={user} history={history} />;
+        if (onMobile) return <Mobile.Header user={user} />;
+    }
 
-    if (onMobile && user) return <Mobile.Header user={user} />;
+    return null;
 
 }

--- a/src/app/(pages)/[username]/flames/page.tsx
+++ b/src/app/(pages)/[username]/flames/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { buildQueryStrings, Flame, Page as FlamesPage, handleFieldErrorsMsg, isEmpty } from "@/core";
+import { buildQueryStrings, handleFieldErrorsMsg } from "@/core";
 import { Element } from "./elements";
 import { IconEyeOff, IconLock, IconNotesOff } from "@tabler/icons-react";
 import { Section } from "../components/Section";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 
@@ -12,98 +11,20 @@ const Page = () => {
 
     const { username } = useParams<{ username: string }>();
     const sParams = useSearchParams();
-
     const query = buildQueryStrings(sParams);
 
-    const { flameService: { searchUserFlames } } = useServices();
+    const { flameServiceQueries: { useSearchUserFlames } } = useServices();
 
     const { isMounted, token } = useUser();
 
-    const [state, setState] = useState({
-        onFetch: false,
-        hasFetched: false,
-        params: sParams.get('q'),
-        page: {} as Omit<FlamesPage<Flame>, 'content'>,
-        flames: [] as Flame[],
-        emptyList: false,
-        notCurrent: false,
-        notMutual: false,
-        notFound: false,
-    })
-
-    const { onFetch, hasFetched, params, page, flames, emptyList, notCurrent, notMutual, notFound } = state;
-
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const init = useCallback(async () => {
-        const accessToken = token ? token.access_token : null;
-        const secret = `${query}:${accessToken}`;
-        if (isFetching.current || hasFetched && params === secret) return;
-        try {
-            startFetch();
-            const { content, ...rest } = await searchUserFlames(accessToken, username, query);
-            return setState((prev) => ({
-                ...prev,
-                params: secret,
-                page: rest,
-                flames: content,
-                emptyList: content.length === 0,
-                notCurrent: false,
-                notMutual: false,
-                notFound: false
-            }))
-        } catch (errors) {
-            if (Array.isArray(errors)) {
-                const { notCurrent, notMutual } = handleFieldErrorsMsg(errors);
-                return setState((prev) => ({
-                    ...prev,
-                    params: secret,
-                    notCurrent: notCurrent,
-                    notMutual: notMutual
-                }))
-            } else return setState((prev) => ({ ...prev, params: secret, notFound: true }));
-        } finally {
-            endFetch();
-        }
-    }, [isMounted, sParams])
-
-    useEffect(() => {
-        if (isMounted) init()
-    }, [init, isMounted])
-
-    if (notFound) return null;
-
-    if (notCurrent) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconEyeOff}
-                title="Notas ocultas"
-                desc="Nome auto explicativo."
-            />
-        </Section>
+    const { data: response, isLoading, isFetching } = useSearchUserFlames(
+        token ? token.access_token : null,
+        username,
+        query,
+        isMounted
     )
 
-    if (notMutual) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconLock}
-                title="Perfil privado"
-                desc="Necessário que ambos de vocês se sigam."
-            />
-        </Section>
-    )
-
-    if (isEmpty(page) || isEmpty(flames)) return (
+    if (isLoading) return (
         <Section className="p-4">
             <Element.header />
             <Element.main />
@@ -111,26 +32,57 @@ const Page = () => {
         </Section>
     )
 
-    return (
-        <Section className="p-4 flex flex-col">
-            <Element.Header />
-            {onFetch
-                ? <Element.Loading />
-                : emptyList
-                    ? <Element.Dialog
-                        icon={IconNotesOff}
-                        title="Zero"
-                        desc="Nada encontrado."
+    if (response) {
+        if (response.type === 'notfound') return null;
+        if (response.type === 'forbidden') {
+            const { notCurrent, notMutual } = handleFieldErrorsMsg(response.data);
+            if (notCurrent) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconEyeOff}
+                        title="Notas ocultas"
+                        desc="Nome auto explicativo."
                     />
-                    :
-                    <>
-                        <Element.Main flames={flames} />
-                        <Element.Footer page={page} isEmpty={emptyList} />
-                    </>
+                </Section>
+            )
+            if (notMutual) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconLock}
+                        title="Perfil privado"
+                        desc="Necessário que ambos de vocês se sigam."
+                    />
+                </Section>
+            )
+        }
+        if (response.type === 'ok') {
+            const { content: flames, ...page } = response.data;
+            const emptyList = flames.length === 0;
+            return (
+                <Section className="p-4 flex flex-col">
+                    <Element.Header />
+                    {isFetching
+                        ? <Element.Loading />
+                        : emptyList
+                            ? <Element.Dialog
+                                icon={IconNotesOff}
+                                title="Zero"
+                                desc="Nada encontrado."
+                            />
+                            :
+                            <>
+                                <Element.Main flames={flames} />
+                                <Element.Footer page={page} isEmpty={emptyList} />
+                            </>
 
-            }
-        </Section>
-    )
+                    }
+                </Section>
+            )
+        }
+        return null;
+    }
+
+    return null;
 
 }
 

--- a/src/app/(pages)/[username]/followers/page.tsx
+++ b/src/app/(pages)/[username]/followers/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { buildQueryStrings, Page as UsersPage, handleFieldErrorsMsg, isEmpty, LowDetailUser } from "@/core";
+import { buildQueryStrings, handleFieldErrorsMsg } from "@/core";
 import { Element } from "./elements";
 import { IconEyeOff, IconLock, IconUsersGroup } from "@tabler/icons-react";
 import { Section } from "../components/Section";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 
@@ -12,96 +11,16 @@ const Page = () => {
 
     const { username } = useParams<{ username: string }>();
     const sParams = useSearchParams();
-
     const query = buildQueryStrings(sParams);
 
-    const { userService: { searchUserFollowers } } = useServices();
+    const { userServiceQueries: { useSearchUserFollowers } } = useServices();
 
     const { isMounted, token } = useUser();
 
-    const [state, setState] = useState({
-        onFetch: false,
-        hasFetched: false,
-        params: sParams.get('q'),
-        page: {} as Omit<UsersPage<LowDetailUser>, 'content'>,
-        users: [] as LowDetailUser[],
-        emptyList: false,
-        notCurrent: false,
-        notMutual: false,
-        notFound: false,
-    })
+    const accessToken = token ? token.access_token : null;
+    const { data: response, isLoading, isFetching } = useSearchUserFollowers(accessToken, username, query, isMounted);
 
-    const { onFetch, hasFetched, params, page, users, emptyList, notCurrent, notMutual, notFound } = state;
-
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const init = useCallback(async () => {
-        const accessToken = token ? token.access_token : null;
-        const secret = `${query}:${accessToken}`;
-        if (isFetching.current || hasFetched && params === secret) return;
-        try {
-            startFetch();
-            const { content, ...rest } = await searchUserFollowers(accessToken, username, query);
-            return setState((prev) => ({
-                ...prev,
-                params: secret,
-                page: rest,
-                users: content,
-                emptyList: content.length === 0,
-                notCurrent: false,
-                notMutual: false,
-                notFound: false
-            }))
-        } catch (errors) {
-            if (Array.isArray(errors)) {
-                const { notCurrent, notMutual } = handleFieldErrorsMsg(errors);
-                return setState((prev) => ({
-                    ...prev,
-                    params: secret,
-                    notCurrent: notCurrent,
-                    notMutual: notMutual
-                }))
-            } else return setState((prev) => ({ ...prev, params: secret, notFound: true }));
-        } finally {
-            endFetch();
-        }
-    }, [isMounted, sParams])
-
-    useEffect(() => { if (isMounted) init() }, [init, isMounted]);
-
-    if (notFound) return null;
-
-    if (notCurrent) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconEyeOff}
-                title="Notas ocultas"
-                desc="Nome auto explicativo."
-            />
-        </Section>
-    )
-
-    if (notMutual) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconLock}
-                title="Perfil privado"
-                desc="Necessário que ambos de vocês se sigam."
-            />
-        </Section>
-    )
-
-    if (isEmpty(page) || isEmpty(users)) return (
+    if (isLoading) return (
         <Section className="p-4">
             <Element.header />
             <Element.main />
@@ -109,26 +28,57 @@ const Page = () => {
         </Section>
     )
 
-    return (
-        <Section className="p-4 flex flex-col">
-            <Element.Header />
-            {onFetch
-                ? <Element.Loading />
-                : emptyList
-                    ? <Element.Dialog
-                        icon={IconUsersGroup}
-                        title="Zero"
-                        desc="Nenhum usuário."
+    if (response) {
+        if (response.type === 'notfound') return null;
+        if (response.type === 'forbidden') {
+            const { notCurrent, notMutual } = handleFieldErrorsMsg(response.data);
+            if (notCurrent) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconEyeOff}
+                        title="Notas ocultas"
+                        desc="Nome auto explicativo."
                     />
-                    :
-                    <>
-                        <Element.Main users={users} />
-                        <Element.Footer page={page} isEmpty={emptyList} />
-                    </>
+                </Section>
+            )
+            if (notMutual) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconLock}
+                        title="Perfil privado"
+                        desc="Necessário que ambos de vocês se sigam."
+                    />
+                </Section>
+            )
+            return null;
+        }
+        if (response.type === 'ok') {
+            const { content, ...page } = response.data;
+            const emptyList = content.length === 0;
+            return (
+                <Section className="p-4 flex flex-col">
+                    <Element.Header />
+                    {isFetching
+                        ? <Element.Loading />
+                        : emptyList
+                            ? <Element.Dialog
+                                icon={IconUsersGroup}
+                                title="Zero"
+                                desc="Nenhum usuário."
+                            />
+                            :
+                            <>
+                                <Element.Main users={content} />
+                                <Element.Footer page={page} isEmpty={emptyList} />
+                            </>
 
-            }
-        </Section>
-    )
+                    }
+                </Section>
+            )
+        }
+        return null;
+    }
+    return null;
 
 }
 

--- a/src/app/(pages)/[username]/following/page.tsx
+++ b/src/app/(pages)/[username]/following/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { buildQueryStrings, Page as UsersPage, handleFieldErrorsMsg, isEmpty, LowDetailUser } from "@/core";
+import { buildQueryStrings, handleFieldErrorsMsg } from "@/core";
 import { Element } from "./elements";
 import { IconEyeOff, IconLock, IconUsersGroup } from "@tabler/icons-react";
 import { Section } from "../components/Section";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 
@@ -12,96 +11,16 @@ const Page = () => {
 
     const { username } = useParams<{ username: string }>();
     const sParams = useSearchParams();
-
     const query = buildQueryStrings(sParams);
 
-    const { userService: { searchUserFollowing } } = useServices();
+    const { userServiceQueries: { useSearchUserFollowing } } = useServices();
 
     const { isMounted, token } = useUser();
 
-    const [state, setState] = useState({
-        onFetch: false,
-        hasFetched: false,
-        params: sParams.get('q'),
-        page: {} as Omit<UsersPage<LowDetailUser>, 'content'>,
-        users: [] as LowDetailUser[],
-        emptyList: false,
-        notCurrent: false,
-        notMutual: false,
-        notFound: false,
-    })
+    const accessToken = token ? token.access_token : null;
+    const { data: response, isLoading, isFetching } = useSearchUserFollowing(accessToken, username, query, isMounted);
 
-    const { onFetch, hasFetched, params, page, users, emptyList, notCurrent, notMutual, notFound } = state;
-
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const init = useCallback(async () => {
-        const accessToken = token ? token.access_token : null;
-        const secret = `${query}:${accessToken}`;
-        if (isFetching.current || hasFetched && params === secret) return;
-        try {
-            startFetch();
-            const { content, ...rest } = await searchUserFollowing(accessToken, username, query);
-            return setState((prev) => ({
-                ...prev,
-                params: secret,
-                page: rest,
-                users: content,
-                emptyList: content.length === 0,
-                notCurrent: false,
-                notMutual: false,
-                notFound: false
-            }))
-        } catch (errors) {
-            if (Array.isArray(errors)) {
-                const { notCurrent, notMutual } = handleFieldErrorsMsg(errors);
-                return setState((prev) => ({
-                    ...prev,
-                    params: secret,
-                    notCurrent: notCurrent,
-                    notMutual: notMutual
-                }))
-            } else return setState((prev) => ({ ...prev, params: secret, notFound: true }));
-        } finally {
-            endFetch();
-        }
-    }, [isMounted, sParams])
-
-    useEffect(() => { if (isMounted) init() }, [init, isMounted]);
-
-    if (notFound) return null;
-
-    if (notCurrent) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconEyeOff}
-                title="Notas ocultas"
-                desc="Nome auto explicativo."
-            />
-        </Section>
-    )
-
-    if (notMutual) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconLock}
-                title="Perfil privado"
-                desc="Necessário que ambos de vocês se sigam."
-            />
-        </Section>
-    )
-
-    if (isEmpty(page) || isEmpty(users)) return (
+    if (isLoading) return (
         <Section className="p-4">
             <Element.header />
             <Element.main />
@@ -109,26 +28,57 @@ const Page = () => {
         </Section>
     )
 
-    return (
-        <Section className="p-4 flex flex-col">
-            <Element.Header />
-            {onFetch
-                ? <Element.Loading />
-                : emptyList
-                    ? <Element.Dialog
-                        icon={IconUsersGroup}
-                        title="Zero"
-                        desc="Nenhum usuário."
+    if (response) {
+        if (response.type === 'notfound') return null;
+        if (response.type === 'forbidden') {
+            const { notCurrent, notMutual } = handleFieldErrorsMsg(response.data);
+            if (notCurrent) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconEyeOff}
+                        title="Notas ocultas"
+                        desc="Nome auto explicativo."
                     />
-                    :
-                    <>
-                        <Element.Main users={users} />
-                        <Element.Footer page={page} isEmpty={emptyList} />
-                    </>
+                </Section>
+            )
+            if (notMutual) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconLock}
+                        title="Perfil privado"
+                        desc="Necessário que ambos de vocês se sigam."
+                    />
+                </Section>
+            )
+            return null;
+        }
+        if (response.type === 'ok') {
+            const { content, ...page } = response.data;
+            const emptyList = content.length === 0;
+            return (
+                <Section className="p-4 flex flex-col">
+                    <Element.Header />
+                    {isFetching
+                        ? <Element.Loading />
+                        : emptyList
+                            ? <Element.Dialog
+                                icon={IconUsersGroup}
+                                title="Zero"
+                                desc="Nenhum usuário."
+                            />
+                            :
+                            <>
+                                <Element.Main users={content} />
+                                <Element.Footer page={page} isEmpty={emptyList} />
+                            </>
 
-            }
-        </Section>
-    )
+                    }
+                </Section>
+            )
+        }
+        return null;
+    }
+    return null;
 
 }
 

--- a/src/app/(pages)/[username]/notes/page.tsx
+++ b/src/app/(pages)/[username]/notes/page.tsx
@@ -3,10 +3,9 @@
 import { buildQueryStrings, handleFieldErrorsMsg } from "@/core";
 import { Element } from "./elements";
 import { IconEyeOff, IconLock, IconNotesOff } from "@tabler/icons-react";
-import { NoteServiceQueries } from '@/services';
 import { Section } from "../components/Section";
 import { useParams, useSearchParams } from "next/navigation";
-import { useUser, useTags } from "@/data/hooks";
+import { useUser, useTags, useServices } from "@/data/hooks";
 
 const Page = () => {
 
@@ -20,7 +19,7 @@ const Page = () => {
     const accessToken = token ? token.access_token : null;
     const isCurrentUser = user ? user.username === username : false;
 
-    const { useFindUserTags, useFindUserNotes } = NoteServiceQueries();
+    const { noteServiceQueries: { useFindUserTags, useFindUserNotes } } = useServices();
 
     const { data: tagsResponse, isLoading: tagsLoading } = useFindUserTags(
         accessToken,

--- a/src/app/(pages)/[username]/notes/page.tsx
+++ b/src/app/(pages)/[username]/notes/page.tsx
@@ -1,115 +1,43 @@
 'use client';
 
-import { buildQueryStrings, handleFieldErrorsMsg, isEmpty, LowDetailNote, Page as NotesPage } from "@/core";
+import { buildQueryStrings, handleFieldErrorsMsg } from "@/core";
 import { Element } from "./elements";
 import { IconEyeOff, IconLock, IconNotesOff } from "@tabler/icons-react";
+import { NoteServiceQueries } from '@/services';
 import { Section } from "../components/Section";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { useServices, useTags, useUser } from "@/data/hooks";
+import { useUser, useTags } from "@/data/hooks";
 
 const Page = () => {
 
     const { username } = useParams<{ username: string }>();
     const sParams = useSearchParams();
-
     const query = buildQueryStrings(sParams);
 
-    const { noteService: { findUserTags, searchUserNotes } } = useServices();
-
-    const { isMounted, token, user } = useUser();
+    const { token, user } = useUser();
     const { tags: currentTags } = useTags();
 
-    const [state, setState] = useState({
-        onFetch: false,
-        hasFetched: false,
-        args: sParams.get('q'),
-        page: {} as Omit<NotesPage<LowDetailNote>, 'content'>,
-        notes: [] as LowDetailNote[],
-        tags: null as string[] | null,
-        emptyList: false,
-        notCurrent: false,
-        notMutual: false,
-        notFound: false,
-    })
+    const accessToken = token ? token.access_token : null;
+    const isCurrentUser = user ? user.username === username : false;
 
-    const { onFetch, hasFetched, args, page, notes, tags, emptyList, notCurrent, notMutual, notFound } = state;
+    const { useFindUserTags, useFindUserNotes } = NoteServiceQueries();
 
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const init = useCallback(async () => {
-        const accessToken = token ? token.access_token : null;
-        const secret = `${query}:${accessToken}`;
-        if (isFetching.current || hasFetched && args === secret) return;
-        try {
-            startFetch();
-            const isCurrentUser = user ? user.username === username : false;
-            const baseTags = isCurrentUser ? currentTags : tags;
-            const userTags = baseTags !== null ? baseTags : await findUserTags(accessToken, username);
-            const { content, ...rest } = await searchUserNotes(accessToken, username, query);
-            return setState((prev) => ({
-                ...prev,
-                args: secret,
-                page: rest,
-                notes: content,
-                tags: userTags,
-                emptyList: content.length === 0,
-                notCurrent: false,
-                notMutual: false,
-                notFound: false
-            }))
-        } catch (errors) {
-            if (Array.isArray(errors)) {
-                const { notCurrent, notMutual } = handleFieldErrorsMsg(errors);
-                return setState((prev) => ({
-                    ...prev,
-                    args: query,
-                    notCurrent: notCurrent,
-                    notMutual: notMutual
-                }))
-            } else return setState((prev) => ({ ...prev, notFound: true }));
-        } finally {
-            endFetch();
-        }
-    }, [isMounted, sParams])
-
-    useEffect(() => {
-        if (isMounted) init();
-    }, [init, isMounted])
-
-    if (notFound) return null;
-
-    if (notCurrent) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconEyeOff}
-                title="Notas ocultas"
-                desc="Nome auto explicativo."
-            />
-        </Section>
+    const { data: tagsResponse, isLoading: tagsLoading } = useFindUserTags(
+        accessToken,
+        username,
+        !isCurrentUser
     )
 
-    if (notMutual) return (
-        <Section className="p-6 flex">
-            <Element.Dialog
-                icon={IconLock}
-                title="Perfil privado"
-                desc="Necessário que ambos de vocês se sigam."
-            />
-        </Section>
+    const { data: notesResponse, isLoading: notesLoading, isFetching: notesFetching } = useFindUserNotes(
+        accessToken,
+        username,
+        query,
+        true
     )
 
-    if (isEmpty(page) || isEmpty(notes)) return (
+    const tags = isCurrentUser ? currentTags : tagsResponse ? tagsResponse.data as string[] : null;
+
+    if (notesLoading || tagsLoading) return (
         <Section className="p-4">
             <Element.header />
             <Element.main />
@@ -117,25 +45,54 @@ const Page = () => {
         </Section>
     )
 
-    return (
-        <Section className="p-4 flex flex-col">
-            <Element.Header tags={tags ?? [] as string[]} />
-            {onFetch
-                ? <Element.Loading />
-                : emptyList
-                    ? <Element.Dialog
-                        icon={IconNotesOff}
-                        title="Zero"
-                        desc="Nada encontrado."
+    if (notesResponse) {
+        if (notesResponse.type === 'notfound') return null;
+        if (notesResponse.type === 'forbidden') {
+            const { notCurrent, notMutual } = handleFieldErrorsMsg(notesResponse.data);
+            if (notCurrent) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconEyeOff}
+                        title="Notas ocultas"
+                        desc="Nome auto explicativo."
                     />
-                    :
-                    <>
-                        <Element.Main notes={notes} />
-                        <Element.Footer page={page} isEmpty={emptyList} />
-                    </>
-            }
-        </Section>
-    )
+                </Section>
+            )
+            if (notMutual) return (
+                <Section className="p-6 flex">
+                    <Element.Dialog
+                        icon={IconLock}
+                        title="Perfil privado"
+                        desc="Necessário que ambos de vocês se sigam."
+                    />
+                </Section>
+            )
+        }
+        if (notesResponse.type === 'ok') {
+            const { content: notes, ...page } = notesResponse.data;
+            const emptyList = notes.length === 0;
+            return (
+                <Section className="p-4 flex flex-col">
+                    <Element.Header tags={tags ?? [] as string[]} />
+                    {notesFetching
+                        ? <Element.Loading />
+                        : emptyList
+                            ? <Element.Dialog
+                                icon={IconNotesOff}
+                                title="Zero"
+                                desc="Nada encontrado."
+                            />
+                            :
+                            <>
+                                <Element.Main notes={notes} />
+                                <Element.Footer page={page} isEmpty={emptyList} />
+                            </>
+                    }
+                </Section>
+            )
+        }
+        return null;
+    }
 
 }
 

--- a/src/app/(pages)/[username]/notes/page.tsx
+++ b/src/app/(pages)/[username]/notes/page.tsx
@@ -13,7 +13,7 @@ const Page = () => {
     const sParams = useSearchParams();
     const query = buildQueryStrings(sParams);
 
-    const { token, user } = useUser();
+    const { isMounted, token, user } = useUser();
     const { tags: currentTags } = useTags();
 
     const accessToken = token ? token.access_token : null;
@@ -24,14 +24,14 @@ const Page = () => {
     const { data: tagsResponse, isLoading: tagsLoading } = useFindUserTags(
         accessToken,
         username,
-        !isCurrentUser
+        isMounted && !isCurrentUser
     )
 
     const { data: notesResponse, isLoading: notesLoading, isFetching: notesFetching } = useFindUserNotes(
         accessToken,
         username,
         query,
-        true
+        isMounted
     )
 
     const tags = isCurrentUser ? currentTags : tagsResponse ? tagsResponse.data as string[] : null;

--- a/src/app/(pages)/[username]/page.tsx
+++ b/src/app/(pages)/[username]/page.tsx
@@ -20,7 +20,7 @@ const Page = () => {
 
     const { data: userData, isLoading } = useGetUser(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
 
-    const user = currentUser ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
+    const user = shouldSkipFetch ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
 
     if (isLoading) return <Overview.Skeleton />;
 

--- a/src/app/(pages)/[username]/page.tsx
+++ b/src/app/(pages)/[username]/page.tsx
@@ -1,46 +1,32 @@
 'use client';
 
 import { IconAt, IconBalloon, IconBubbleText, IconUsers, IconUsersGroup } from "@tabler/icons-react";
-import { LowDetailUser, toSpecificTime, User } from "@/core";
 import { Overview } from "./overview";
 import { Section } from "./components/Section";
-import { useEffect, useRef, useState } from "react";
+import { toSpecificTime } from "@/core";
 import { useParams } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 
 const Page = () => {
 
-    const { userService: { getUser } } = useServices();
-
-    const { isMounted, user: current } = useUser();
+    const { userServiceQueries: { useGetUser } } = useServices();
 
     const params = useParams<{ username: string }>();
 
-    const [notFound, setNotFound] = useState<boolean>(false);
-    const [user, setUser] = useState<User | LowDetailUser | null>(null);
+    const { isMounted, user: currentUser } = useUser();
 
-    const isFetching = useRef<boolean>(false);
-    useEffect(() => {
-        const init = async () => {
-            if (isFetching.current) return;
-            if (current && params.username === current.username) return setUser(current);
-            isFetching.current = true;
-            try {
-                return setUser(await getUser(params.username));
-            } catch {
-                return setNotFound(true);
-            } finally {
-                return isFetching.current = false;
-            }
-        }
-        if (isMounted) init();
-    }, [current, getUser, isMounted, params.username])
+    const shouldSkipHeader: boolean = params.username === "user";
+    const shouldSkipFetch: boolean = currentUser ? currentUser.username === params.username : false;
 
-    if (notFound) return null;
+    const { data: userData, isLoading } = useGetUser(params.username, isMounted && !shouldSkipHeader && !shouldSkipFetch);
 
-    if (!user) return <Overview.Skeleton />;
+    const user = currentUser ? currentUser : userData && userData.type === 'ok' ? userData.data : null;
 
-    return (
+    if (isLoading) return <Overview.Skeleton />;
+
+    if (userData && userData.type === 'notfound') return null;
+
+    if (user) return (
         <Section>
             <header className="py-5 px-8 border-b dark:border-neutral-700/50 border-dark/10">
                 <h2 className="font-semibold text-xl inmd:text-center">Visão Geral</h2>
@@ -86,6 +72,8 @@ const Page = () => {
             </ul>
         </Section>
     )
+
+    return null;
 
 }
 

--- a/src/app/(pages)/dashboard/user/aside/ranking/index.tsx
+++ b/src/app/(pages)/dashboard/user/aside/ranking/index.tsx
@@ -1,29 +1,19 @@
 import { Element } from "./elements"
-import { isEmpty, LowDetailNote, Page } from "@/core";
 import { Skeleton } from "./skeleton";
 import { Toggle } from "@/components/buttons";
-import { useCallback, useEffect, useState } from "react";
 import { useServices } from "@/data/hooks";
 
 export const Ranking = () => {
 
-    const { noteService: { searchNotes } } = useServices();
+    const { noteServiceQueries: { useSearchNotes } } = useServices();
 
-    const [ranking, setRanking] = useState<Page<LowDetailNote>>({} as Page<LowDetailNote>);
-
-    const getTopThreeNotes = useCallback(async () => {
-        return setRanking(await searchNotes('size=3'));
-    }, [searchNotes])
-
-    useEffect(() => {
-        getTopThreeNotes();
-    }, [getTopThreeNotes])
+    const { data: ranking, isLoading } = useSearchNotes('sort=flamesCount,desc&size=3');
 
     const { Title, Li, Target, Desc, Link } = Element;
 
-    if (isEmpty(ranking)) return <Skeleton />;
+    if (isLoading) return <Skeleton />;
 
-    return (
+    if (ranking) return (
         <section
             className="w-full h-fit p-3 rounded-[5px]
             dark:bg-darker bg-lighter
@@ -46,5 +36,7 @@ export const Ranking = () => {
             <Link />
         </section>
     )
+
+    return null;
 
 }

--- a/src/app/(pages)/dashboard/user/feed/index.tsx
+++ b/src/app/(pages)/dashboard/user/feed/index.tsx
@@ -1,104 +1,64 @@
 import { Empty } from "./empty";
 import { Header } from "./header";
 import { Icon } from "@/components/icons";
-import { isEmpty, LowDetailNote, Page } from "@/core";
 import { Item } from "./item";
+import { LowDetailNote } from "@/core";
 import { Skeleton } from "./skeleton";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useCallback } from "react";
 import { useServices, useUser } from "@/data/hooks";
 
 export const Feed = () => {
 
-    const { noteService: { getFeedNotes } } = useServices();
-
+    const { noteServiceQueries: { useGetFeed } } = useServices();
     const { isMounted, token } = useUser();
 
-    const [state, setState] = useState({
-        onFetch: false,
-        hasFetched: false,
-        page: {} as Omit<Page<LowDetailNote>, 'content'>,
-        notes: [] as LowDetailNote[],
-        emptyFeed: false
-    })
+    const accessToken = token ? token.access_token : 'token';
 
-    const { onFetch, hasFetched, page, notes, emptyFeed } = state;
+    const {
+        data: data,
+        isLoading,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
+    } = useGetFeed(accessToken, isMounted)
 
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const init = useCallback(async () => {
-        if (isFetching.current || hasFetched || !token) return;
-        try {
-            startFetch();
-            const { content, ...rest } = await getFeedNotes(token.access_token, 'page=0');
-            return setState((prev) => ({
-                ...prev,
-                page: rest,
-                notes: content,
-                emptyFeed: content.length === 0
-            }))
-        } catch (error) {
-            throw error;
-        } finally {
-            endFetch();
-        }
-    }, [endFetch, getFeedNotes, hasFetched, startFetch, token])
-
-    const handleScroll = useCallback(async () => {
-        if (!token || page.last || isFetching.current) return;
+    const handleScroll = useCallback(() => {
+        if (!hasNextPage || isFetchingNextPage) return;
         const scrollY = window.scrollY;
         const windowHeight = window.innerHeight;
         const docHeight = document.documentElement.scrollHeight;
-        if (scrollY + windowHeight >= docHeight - 1) {
-            try {
-                startFetch()
-                const { content, ...rest } = await getFeedNotes(token.access_token, `page=${page.page + 1}`);
-                return setState((prev) => ({
-                    ...prev,
-                    page: rest,
-                    notes: [...prev.notes, ...content]
-                }))
-            } finally {
-                endFetch();
-            }
-        }
-    }, [endFetch, getFeedNotes, page.last, page.page, startFetch, token]);
+        if (scrollY + windowHeight >= docHeight - 1) fetchNextPage();
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
     useEffect(() => {
-        if (isMounted) init();
         window.addEventListener("scroll", handleScroll);
         return () => window.removeEventListener("scroll", handleScroll);
-    }, [handleScroll, init, isMounted])
+    }, [handleScroll])
 
-    if (isEmpty(page)) return <Skeleton />;
+    if (isLoading) return <Skeleton />;
 
-    if (emptyFeed) return <Empty />;
+    if (data) {
+        const notes: LowDetailNote[] = data.pages.flatMap(p => p.content) ?? [];
+        if (notes.length === 0) return <Empty />;
+        return (
+            <section
+                className="max-w-[777px] inlg:max-w-full w-full my-3 p-3 rounded-[5px]
+                dark:bg-darker bg-lighter
+                dark:drop-shadow-alpha-l-sm drop-shadow-alpha-d-sm"
+            >
+                <Header />
+                <ul className="flex flex-col gap-4">
+                    {notes.map((note) => (
+                        <li key={note.id}>
+                            <Item note={note} />
+                        </li>
+                    ))}
+                </ul>
+                <Icon.Loading hidden={!isFetchingNextPage} size={50} className="py-6" />
+            </section>
+        )
+    }
 
-    return (
-        <section
-            className="max-w-[777px] inlg:max-w-full w-full my-3 p-3 rounded-[5px]
-            dark:bg-darker bg-lighter
-            dark:drop-shadow-alpha-l-sm drop-shadow-alpha-d-sm"
-        >
-            <Header />
-            <ul className="flex flex-col gap-4">
-                {notes.map((note) => (
-                    <li key={note.id}>
-                        <Item note={note} />
-                    </li>
-                ))}
-            </ul>
-            <Icon.Loading hidden={!onFetch} size={50} className="py-6" />
-        </section>
-    )
+    return null;
 
 }

--- a/src/app/(pages)/search/page.tsx
+++ b/src/app/(pages)/search/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { buildQueryStrings, isEmpty, LowDetailNote, LowDetailUser, Page as Pageable } from "@/core";
+import { buildQueryStrings, LowDetailNote, LowDetailUser } from "@/core";
 import { Device } from "@/components/devices";
 import { Element } from "./elements";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { useServices, useUser } from "@/data/hooks";
+import { useServices } from "@/data/hooks";
+import { useState } from "react";
 
 const Page = () => {
 
@@ -15,73 +15,28 @@ const Page = () => {
     const type = sParams.get('type');
 
     const {
-        userService: { searchUsers },
-        noteService: { searchNotes, searchTags }
+        userServiceQueries: { useSearchUsers },
+        noteServiceQueries: { useSearchNotes, useSearchTags }
     } = useServices();
 
-    const { isMounted } = useUser();
+    const { data: notesData, isLoading: notesLoading, isFetching: notesFetching } = useSearchNotes(query, type === 'notes' || !type);
+    const { data: usersData, isLoading: usersLoading, isFetching: usersFetching } = useSearchUsers(query, type === 'users');
+    const { data: tagsData, isLoading: tagsLoading, isFetching: tagsFetching } = useSearchTags(query, type === 'tags');
 
-    const [state, setState] = useState({
-        onFetch: false,
-        page: {} as Omit<Pageable<(LowDetailUser | LowDetailNote)>, "content">,
-        contents: [] as (LowDetailUser | LowDetailNote)[],
-        emptyList: false
-    })
+    const isLoading = usersLoading || notesLoading || tagsLoading;
+    const isFetching = usersFetching || notesFetching || tagsFetching;
 
-    const { onFetch, page, contents, emptyList } = state;
-
-    const isFetching = useRef<boolean>(false);
-
-    const startFetch = useCallback(() => {
-        isFetching.current = true;
-        return setState((prev) => ({ ...prev, onFetch: true }));
-    }, [])
-
-    const endFetch = useCallback(() => {
-        isFetching.current = false;
-        return setState((prev) => ({ ...prev, onFetch: false, hasFetched: true }));
-    }, [])
-
-    const getPage = useCallback(async (query: string): Promise<Pageable<(LowDetailUser | LowDetailNote)>> => {
-        if (type === "tags") return await searchTags(query);
-        else if (type === "users") return await searchUsers(query);
-        else if (type === "notes") return await searchNotes(query);
-        else return await searchNotes(query);
-    }, [searchNotes, searchTags, searchUsers, type])
-
-    const init = useCallback(async () => {
-        if (isFetching.current) return;
-        try {
-            startFetch();
-            const { content, ...rest } = await getPage(query);
-            return setState((prev) => ({
-                ...prev,
-                page: rest,
-                contents: content,
-                emptyList: content.length === 0,
-            }))
-        } catch (error) {
-            throw error;
-        } finally {
-            endFetch();
-        }
-    }, [isMounted, sParams])
-
-    useEffect(() => {
-        if (isMounted) init()
-    }, [init, isMounted])
+    const page = type === 'users' ? usersData : type === 'tags' ? tagsData : notesData;
+    const contents = page ? page.content as (LowDetailUser | LowDetailNote)[] : [];
 
     const { Header, Aside, Results, Loading } = Element;
 
-    if (isEmpty(page)) return (
+    if (isLoading) return (
         <div className="w-full h-full py-4 px-4 inlg:px-2 inmd:p-0 flex flex-col gap-6 inmd:gap-0 dark:bg-dark bg-light">
             <Device.Mobile.Header.SearchHeader query={q} setQuery={setQ} disabled />
             <div className="w-full h-full flex flex-col">
                 <Element.header />
-                <div
-                    className="max-w-[888px] w-full m-auto flex-1 flex justify-center gap-3
-                    inlg:flex-col inlg:gap-0"
-                >
+                <div className="max-w-[888px] w-full m-auto flex-1 flex justify-center gap-3 inlg:flex-col inlg:gap-0">
                     <Element.aside />
                     <Element.results />
                 </div>
@@ -89,32 +44,29 @@ const Page = () => {
         </div>
     )
 
-    return (
+    if (page) return (
         <main className="w-full h-full py-4 px-4 inlg:px-2 inmd:p-0 flex flex-col gap-6 inmd:gap-0 dark:bg-dark bg-light">
             <Device.Mobile.Header.SearchHeader query={q} setQuery={setQ} />
             <section className="w-full h-full flex flex-col">
                 <Header />
-                <section
-                    className="max-w-[888px] w-full m-auto flex-1 flex justify-center gap-3
-                    inlg:flex-col inlg:gap-0"
-                >
+                <section className="max-w-[888px] w-full m-auto flex-1 flex justify-center gap-3 inlg:flex-col inlg:gap-0">
                     <Aside />
-                    {onFetch
-                        ?
-                        <Loading />
-                        :
-                        <Results
+                    {isFetching
+                        ? <Loading />
+                        : <Results
                             page={page}
                             contents={contents}
-                            isEmpty={emptyList}
+                            isEmpty={contents.length === 0}
                             totalElements={page.totalElements}
                         />
                     }
                 </section>
             </section>
-        </main >
+        </main>
     )
+
+    return null;
 
 }
 
-export default Page
+export default Page;

--- a/src/components/buttons/Flame.tsx
+++ b/src/components/buttons/Flame.tsx
@@ -3,6 +3,7 @@ import { IconFlame } from '@tabler/icons-react';
 import { LowDetailNote } from '@/core';
 import { useCallback, useState } from 'react';
 import { useFlames, useServices, useUser } from '@/data/hooks';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface FlameProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     size?: number;
@@ -13,6 +14,7 @@ interface FlameProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export const Flame = ({ size = 24, note, useCount, ...rest }: FlameProps) => {
 
     const { flameService: { inflameNote, deflameNote } } = useServices();
+    const qc = useQueryClient();
 
     const { token, user } = useUser();
     const { flames, setNewFlame, removeFlame } = useFlames();
@@ -26,24 +28,26 @@ export const Flame = ({ size = 24, note, useCount, ...rest }: FlameProps) => {
     const [reqDeflame, setReqDeflame] = useState<boolean>(false);
 
     const inflame = useCallback(async () => {
-        if (!token) return;
+        if (!token || !user) return;
         setRequesting(true);
         setReqInflame(true);
         try {
             setNewFlame(await inflameNote(token.access_token, note.id));
+            await qc.invalidateQueries({ queryKey: ['flames', token.access_token, user.username], refetchType: 'none' });
         } finally {
             setRequesting(false);
             setReqInflame(false);
             setCount((prev) => (prev + 1));
         }
-    }, [inflameNote, note.id, setNewFlame, token])
+    }, [inflameNote, note.id, qc, setNewFlame, token, user])
 
     const deflame = useCallback(async () => {
-        if (!token) return;
+        if (!token || !user) return;
         setRequesting(true);
         setReqDeflame(true);
         try {
             await deflameNote(token.access_token, note.id);
+            await qc.invalidateQueries({ queryKey: ['flames', token.access_token, user.username], refetchType: 'none' });
             removeFlame(note);
         } finally {
             setHovering(false);
@@ -51,7 +55,7 @@ export const Flame = ({ size = 24, note, useCount, ...rest }: FlameProps) => {
             setReqDeflame(false);
             setCount((prev) => (prev - 1));
         }
-    }, [deflameNote, note, removeFlame, token])
+    }, [deflameNote, note, qc, removeFlame, token, user])
 
     const Button = ({ className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
         <button

--- a/src/components/buttons/Follow.tsx
+++ b/src/components/buttons/Follow.tsx
@@ -5,6 +5,7 @@ import { IconUserCheck, IconUserMinus, IconUserPlus } from "@tabler/icons-react"
 import { LowDetailUser } from "@/core";
 import { useCallback, useState } from "react";
 import { useFollowing, useServices, useUser } from "@/data/hooks";
+import { useQueryClient } from '@tanstack/react-query';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     user: LowDetailUser;
@@ -15,6 +16,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export const Follow = ({ user, useIcon, useText, className, ...rest }: ButtonProps) => {
 
     const { userService: { followUser, unfollowUser } } = useServices();
+    const qc = useQueryClient();
 
     const { token, user: current } = useUser();
     const { users, setNewFollowing, removeFollowing } = useFollowing();
@@ -27,31 +29,39 @@ export const Follow = ({ user, useIcon, useText, className, ...rest }: ButtonPro
     const [reqUnfollow, setReqUnfollow] = useState<boolean>(false);
 
     const follow = useCallback(async () => {
-        if (!token) return;
+        if (!token || !current) return;
         setRequesting(true);
         setReqFollow(true);
         try {
             await followUser(token.access_token, user.username);
+            await Promise.all([
+                qc.invalidateQueries({ queryKey: ['feed', token.access_token], refetchType: 'none' }),
+                qc.invalidateQueries({ queryKey: ['following', token.access_token, current.username], refetchType: 'none' })
+            ])
             setNewFollowing(user);
         } finally {
             setRequesting(false);
             setReqFollow(false);
         }
-    }, [followUser, setNewFollowing, token, user])
+    }, [current, followUser, qc, setNewFollowing, token, user])
 
     const unfollow = useCallback(async () => {
-        if (!token) return;
+        if (!token || !current) return;
         setRequesting(true);
         setReqUnfollow(true);
         try {
             await unfollowUser(token.access_token, user.username);
+            await Promise.all([
+                qc.invalidateQueries({ queryKey: ['feed', token.access_token], refetchType: 'none' }),
+                qc.invalidateQueries({ queryKey: ['following', token.access_token, current.username], refetchType: 'none' })
+            ])
             removeFollowing(user);
         } finally {
             setHovering(false);
             setRequesting(false);
             setReqUnfollow(false);
         }
-    }, [removeFollowing, token, unfollowUser, user])
+    }, [current, qc, removeFollowing, token, unfollowUser, user])
 
     const HTMLButton = ({ className, ...rest }: { className?: string } & React.HTMLAttributes<HTMLButtonElement>) => (
         <button

--- a/src/components/forms/comment/new/index.tsx
+++ b/src/components/forms/comment/new/index.tsx
@@ -3,6 +3,7 @@ import { Comment, CreateCommentFormData, createCommentFormSchema, handleFieldErr
 import { Component } from "@/components";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
+import { useQueryClient } from '@tanstack/react-query';
 import { useRef, useState, useTransition } from "react";
 import { useServices } from "@/data/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -18,6 +19,7 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 export const Form = ({ token, user, note, setComments, setNote, ...rest }: FormProps) => {
 
     const { commentService: { createComment } } = useServices();
+    const qc = useQueryClient();
 
     const createCommentForm = useForm<CreateCommentFormData>({
         resolver: zodResolver(createCommentFormSchema)
@@ -42,6 +44,7 @@ export const Form = ({ token, user, note, setComments, setNote, ...rest }: FormP
     const onSubmit = (data: CreateCommentFormData) => startTransition(async (): Promise<void> => {
         try {
             const comment = await createComment(token.access_token, note.id, data);
+            await qc.invalidateQueries({ queryKey: ['comments', token.access_token, note.id], refetchType: 'none' });
             if (textareaRef.current) textareaRef.current.style.height = "auto";
             setIsTyping(false);
             setComment("");

--- a/src/components/forms/comment/update/index.tsx
+++ b/src/components/forms/comment/update/index.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { Comment, CreateCommentFormData, createCommentFormSchema, handleFieldErrors, Note, Page, Reply, Token, User } from "@/core";
+import { Comment, CreateCommentFormData, createCommentFormSchema, handleFieldErrors, Note, Reply, Token, User } from "@/core";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { IconEdit, IconX } from "@tabler/icons-react";
@@ -17,7 +17,6 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
     isRepliesListOpen: boolean;
     setNote: React.Dispatch<React.SetStateAction<Note | null>>;
     setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
-    setRepliesPage: React.Dispatch<React.SetStateAction<Omit<Page<Reply>, 'content'>>>;
     setReplies: React.Dispatch<React.SetStateAction<Reply[]>>;
     setIsRepliesListOpen: React.Dispatch<React.SetStateAction<boolean>>;
     setIsReplying: React.Dispatch<React.SetStateAction<boolean>>;
@@ -32,13 +31,15 @@ export const Form = ({
     isRepliesListOpen,
     setNote,
     setComments,
-    setRepliesPage,
     setReplies,
     setIsReplying,
     setIsRepliesListOpen,
     ...rest }: FormProps) => {
 
-    const { commentService: { editComment, deleteComment }, replyService: { getReplies } } = useServices();
+    const {
+        commentService: { editComment, deleteComment },
+        replyServiceQueries: { useGetReplies }
+    } = useServices();
 
     const editCommentForm = useForm<CreateCommentFormData>({
         resolver: zodResolver(createCommentFormSchema)
@@ -54,11 +55,9 @@ export const Form = ({
     const [initialText, setInitialText] = useState<string>(comment.text);
     const [current, setCurrent] = useState<string>(initialText);
     const [modified, setModified] = useState<boolean>(comment.modified);
-    const [hasFetchedRepliesList, setHasFetchedRepliesList] = useState<boolean>(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const [isPending, startTransition] = useTransition();
-    const [isRepliesFetchPending, startRepliesTransition] = useTransition();
 
     const toggleMenu = () => setIsMenuOpen(prev => !prev);
 
@@ -95,19 +94,21 @@ export const Form = ({
 
     const openReplyBox = () => setIsReplying(true);
 
-    const openRepliesList = () => startRepliesTransition(async () => {
-        if (hasFetchedRepliesList) return setIsRepliesListOpen(prev => !prev);
-        try {
-            const accessToken = token ? token.access_token : null;
-            const { content, ...rest } = await getReplies(accessToken, comment.id, 'page=0');
-            setRepliesPage(rest);
-            setReplies(content);
+    const { data, fetchNextPage, isLoading } = useGetReplies(token ? token.access_token : null, comment.id, false);
+    const openRepliesList = () => {
+        if (data) {
             setIsRepliesListOpen(prev => !prev);
-            setHasFetchedRepliesList(true);
-        } catch (error) {
-            throw error;
+            setReplies(data.pages.flatMap(p => p.content));
+            return;
         }
-    })
+        fetchNextPage().then((result) => {
+            if (result.data) {
+                const replies = result.data.pages.flatMap(p => p.content);
+                setReplies(replies);
+                setIsRepliesListOpen(prev => !prev);
+            }
+        })
+    }
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => setCurrent(e.target.value);
 
@@ -236,7 +237,7 @@ export const Form = ({
                         <Button
                             type="button"
                             disabled={repliesCount < 1}
-                            isPending={isRepliesFetchPending}
+                            isPending={isLoading}
                             onClick={openRepliesList}
                             className="flex items-center gap-1 font-medium dark:text-secondary text-primary dark:hover:secondary/20 hover:bg-primary/20"
                         >

--- a/src/components/forms/comment/update/index.tsx
+++ b/src/components/forms/comment/update/index.tsx
@@ -4,7 +4,8 @@ import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { IconEdit, IconX } from "@tabler/icons-react";
 import { Menu, MenuButton, MenuItem } from "@/components/menu";
-import { useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useQueryClient } from '@tanstack/react-query';
 import { useServices } from "@/data/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -40,6 +41,7 @@ export const Form = ({
         commentService: { editComment, deleteComment },
         replyServiceQueries: { useGetReplies }
     } = useServices();
+    const qc = useQueryClient();
 
     const editCommentForm = useForm<CreateCommentFormData>({
         resolver: zodResolver(createCommentFormSchema)
@@ -58,6 +60,12 @@ export const Form = ({
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const [isPending, startTransition] = useTransition();
+
+    useEffect(() => {
+        setInitialText(comment.text);
+        setCurrent(comment.text);
+        setModified(comment.modified);
+    }, [comment.text, comment.modified])
 
     const toggleMenu = () => setIsMenuOpen(prev => !prev);
 
@@ -116,6 +124,7 @@ export const Form = ({
         try {
             if (token) {
                 await editComment(token.access_token, comment.id, data);
+                await qc.invalidateQueries({ queryKey: ['comments', token.access_token, note.id], refetchType: 'none' });
                 setInitialText(data.text);
                 setCurrent(data.text);
                 setReadOnly(true);
@@ -131,6 +140,7 @@ export const Form = ({
     const handleDeleteComment = () => startTransition(async () => {
         if (token) {
             await deleteComment(token.access_token, comment.id);
+            await qc.invalidateQueries({ queryKey: ['comments', token.access_token, note.id], refetchType: 'none' });
             setComments(prev => prev.filter((c) => c.id != comment.id));
             setNote((prev) => {
                 if (prev) return { ...prev, comments_count: prev.comments_count - 1 };

--- a/src/components/forms/note/new/index.tsx
+++ b/src/components/forms/note/new/index.tsx
@@ -3,6 +3,7 @@ import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { IconEyeClosed, IconMessage, IconMessageOff, IconWorld } from "@tabler/icons-react";
 import { useNotes, useServices } from "@/data/hooks";
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -10,6 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 export const Form = ({ token, username }: { token: string; username: string; }) => {
 
     const { noteService: { createNote } } = useServices();
+    const qc = useQueryClient();
 
     const { setNewNote } = useNotes();
 
@@ -27,6 +29,12 @@ export const Form = ({ token, username }: { token: string; username: string; }) 
         try {
             setIsPending(true);
             const note = await createNote(token, data);
+            await Promise.all([
+                qc.invalidateQueries({ queryKey: ['userNotes', token, username] }),
+                qc.invalidateQueries({ queryKey: ['userTags', token, username] }),
+                qc.invalidateQueries({ queryKey: ['searchNotes'] }),
+                qc.invalidateQueries({ queryKey: ['searchTags'] })
+            ])
             setNewNote(note);
             router.push(`/${username}/${note.id}`);
         } catch (errors) {

--- a/src/components/forms/note/update-text/index.tsx
+++ b/src/components/forms/note/update-text/index.tsx
@@ -5,6 +5,7 @@ import { Menu, MenuItem } from "@/components/menu";
 import { Note, NoteTextUpdateFormData, noteTextUpdateFormSchema, Token } from "@/core"
 import { useEffect, useState } from "react";
 import { useNotes, useServices, useTags } from "@/data/hooks";
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -18,6 +19,8 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) => {
 
     const { noteService: { updateNoteText, deleteNote } } = useServices();
+    const qc = useQueryClient();
+
     const { setNoteToFirst, removeNote } = useNotes();
     const { removeTags } = useTags();
 
@@ -53,7 +56,7 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
     const onSubmit = async (data: NoteTextUpdateFormData): Promise<void> => {
         if (token) {
             setIsPending(true);
-            return await updateNoteText(token.access_token, note.id, data)
+            await updateNoteText(token.access_token, note.id, data)
                 .then(() => {
                     setIsSubmiting(false);
                     setIsEditing(false);
@@ -63,6 +66,7 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
                     setNoteToFirst(note.id);
                     setIsPending(false);
                 })
+            return await qc.invalidateQueries({ queryKey: ['note', token.access_token, note.id] });
         }
     }
 
@@ -70,13 +74,20 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
         e.stopPropagation();
         if (token) {
             setIsPending(true);
-            return await deleteNote(token.access_token, note.id)
+            await deleteNote(token.access_token, note.id)
                 .then(() => {
                     setIsPending(false);
                     removeTags(note.tags);
                     removeNote(note.id);
-                    router.push(`/${currentUser}/notes`);
                 })
+            await Promise.all([
+                qc.invalidateQueries({ queryKey: ['userNotes', token.access_token] }),
+                qc.invalidateQueries({ queryKey: ['userTags', token.access_token] }),
+                qc.invalidateQueries({ queryKey: ['searchNotes'] }),
+                qc.invalidateQueries({ queryKey: ['searchTags'] }),
+                qc.invalidateQueries({ queryKey: ['note', token.access_token, note.id] })
+            ])
+            return router.push(`/${currentUser}/notes`);
         }
     }
 

--- a/src/components/forms/note/update/index.tsx
+++ b/src/components/forms/note/update/index.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { forwardRef, useState } from "react";
 import { handleFieldErrors, Note, NoteUpdateFormData, noteUpdateFormSchema, Token } from "@/core";
 import { useNotes, useServices, useTags } from "@/data/hooks";
+import { useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from "@hookform/resolvers/zod";
 
 interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
@@ -16,6 +17,7 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 export const Form = forwardRef<HTMLFormElement, FormProps>(({ onPortalClose, closeRef, token, note, setNote, ...rest }, ref) => {
 
     const { noteService: { updateNote } } = useServices();
+    const qc = useQueryClient();
 
     const { updateNote: updateNoteContext } = useNotes();
     const { setNewTags } = useTags();
@@ -33,6 +35,13 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ onPortalClose, clo
             try {
                 setIsPending(true);
                 await updateNote(token.access_token, note.id, data);
+                await Promise.all([
+                    qc.invalidateQueries({ queryKey: ['userNotes', token.access_token] }),
+                    qc.invalidateQueries({ queryKey: ['userTags', token.access_token] }),
+                    qc.invalidateQueries({ queryKey: ['searchNotes'] }),
+                    qc.invalidateQueries({ queryKey: ['searchTags'] }),
+                    qc.invalidateQueries({ queryKey: ['note', token.access_token, note.id] })
+                ])
                 updateNoteContext(note.id, data);
                 setNewTags(data.tags);
                 setNote(prev => {

--- a/src/components/forms/reply/new/index.tsx
+++ b/src/components/forms/reply/new/index.tsx
@@ -1,8 +1,9 @@
 import { clsx } from "clsx";
-import { Comment, createCommentFormSchema, CreateReplyFormData, handleFieldErrors, Reply, Token, User } from "@/core";
+import { Comment, createCommentFormSchema, CreateReplyFormData, handleFieldErrors, Page, Reply, Token, User } from "@/core";
 import { Component } from "@/components";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { useRef, useState, useTransition } from "react";
 import { useServices } from "@/data/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -19,9 +20,12 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
     setIsReplying: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+type RepliesCache = InfiniteData<Page<Reply>>;
+
 export const Form = ({ useSelfReference, token, user, comment, isReplying, selfReferenceReply, setReplies, setRepliesCount, setIsReplying, ...rest }: FormProps) => {
 
     const { replyService: { createReply, createSelfReferenceReply } } = useServices();
+    const qc = useQueryClient();
 
     const createReplyForm = useForm<CreateReplyFormData>({
         resolver: zodResolver(createCommentFormSchema)
@@ -55,6 +59,19 @@ export const Form = ({ useSelfReference, token, user, comment, isReplying, selfR
             setReplies(prev => [...prev, reply]);
             setRepliesCount(prev => prev + 1);
             setIsReplying(false);
+            qc.setQueryData<RepliesCache>(
+                ['replies', token.access_token, comment.id],
+                (oldData) => {
+                    if (oldData) return {
+                        ...oldData,
+                        pages: oldData.pages.map((page, index: number) => {
+                            if (index === 0) return { ...page, content: [...page.content, reply] };
+                            return page;
+                        })
+                    }
+                    return oldData;
+                }
+            )
         } catch (errors) {
             if (Array.isArray(errors)) return handleFieldErrors(errors, setError);
         }

--- a/src/components/forms/reply/update/index.tsx
+++ b/src/components/forms/reply/update/index.tsx
@@ -1,8 +1,9 @@
 import { clsx } from "clsx";
-import { CreateReplyFormData, createReplyFormSchema, handleFieldErrors, Note, Reply, Token, User } from "@/core";
+import { Comment, CreateReplyFormData, createReplyFormSchema, handleFieldErrors, Note, Page, Reply, Token, User } from "@/core";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { IconEdit, IconX } from "@tabler/icons-react";
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Menu, MenuButton, MenuItem } from "@/components/menu";
 import { useRef, useState, useTransition } from "react";
 import { useServices } from "@/data/hooks";
@@ -12,15 +13,19 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
     token: Token | null;
     user: User | null;
     note: Note;
+    comment: Comment;
     reply: Reply;
     setReplies: React.Dispatch<React.SetStateAction<Reply[]>>;
     setRepliesCount: React.Dispatch<React.SetStateAction<number>>;
     setIsReplying: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const Form = ({ token, user, note, reply, setReplies, setRepliesCount, setIsReplying, ...rest }: FormProps) => {
+type RepliesCache = InfiniteData<Page<Reply>>;
+
+export const Form = ({ token, user, note, comment, reply, setReplies, setRepliesCount, setIsReplying, ...rest }: FormProps) => {
 
     const { replyService: { editReply, deleteReply } } = useServices();
+    const qc = useQueryClient();
 
     const editReplyForm = useForm<CreateReplyFormData>({
         resolver: zodResolver(createReplyFormSchema)
@@ -87,6 +92,21 @@ export const Form = ({ token, user, note, reply, setReplies, setRepliesCount, se
                 setIsTyping(false);
                 setModified(true);
                 setIsExpanded(true);
+                qc.setQueryData<RepliesCache>(
+                    ['replies', token.access_token, comment.id],
+                    (oldData) => {
+                        if (oldData) return {
+                            ...oldData,
+                            pages: oldData.pages.map((page) => ({
+                                ...page,
+                                content: page.content.map((item) =>
+                                    item.id === reply.id ? { ...item, text: data.text, modified: true } : item
+                                )
+                            }))
+                        }
+                        return oldData;
+                    }
+                )
             }
         } catch (errors) {
             if (Array.isArray(errors)) return handleFieldErrors(errors, setError);
@@ -98,6 +118,19 @@ export const Form = ({ token, user, note, reply, setReplies, setRepliesCount, se
             await deleteReply(token.access_token, reply.id);
             setReplies(prev => prev.filter((r) => r.id != reply.id));
             setRepliesCount(prev => prev - 1);
+            qc.setQueryData<RepliesCache>(
+                ['replies', token.access_token, comment.id],
+                (oldData) => {
+                    if (oldData) return {
+                        ...oldData,
+                        pages: oldData.pages.map((page) => ({
+                            ...page,
+                            content: page.content.filter((item) => item.id !== reply.id)
+                        }))
+                    }
+                    return oldData;
+                }
+            )
         }
     })
 

--- a/src/components/forms/user/delete/index.tsx
+++ b/src/components/forms/user/delete/index.tsx
@@ -1,6 +1,7 @@
 import { DeleteUserFormData, deleteUserFormSchema, handleFieldErrors } from "@/core";
 import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 import { useState } from "react";
@@ -9,6 +10,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 export const Form = () => {
 
     const { userService: { deleteUser } } = useServices();
+    const qc = useQueryClient();
+
     const { token, user, clearUser } = useUser();
 
     const deleteUserForm = useForm<DeleteUserFormData>({
@@ -21,10 +24,14 @@ export const Form = () => {
     const router = useRouter();
 
     const onSubmit = async (data: DeleteUserFormData): Promise<void> => {
-        if (token)
+        if (token && user)
             try {
                 setIsPending(true);
                 await deleteUser(token.access_token, data);
+                await Promise.all([
+                    qc.invalidateQueries({ queryKey: ['user', user.username] }),
+                    qc.invalidateQueries({ queryKey: ['searchUsers'] }),
+                ])
                 clearUser({ skipLogout: true });
                 return router.push("/");
             } catch (errors: any) {

--- a/src/components/forms/user/update/index.tsx
+++ b/src/components/forms/user/update/index.tsx
@@ -5,6 +5,7 @@ import { Element } from "./elements";
 import { FormProvider, useForm } from "react-hook-form";
 import { forwardRef, useState, useTransition } from "react";
 import { IconX } from "@tabler/icons-react";
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
 import { useServices, useUser } from "@/data/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,6 +18,7 @@ interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
 export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortalClose, ...rest }, ref) => {
 
     const { userService: { updateUser } } = useServices();
+    const qc = useQueryClient();
 
     const { token, user, updateUser: editUser } = useUser();
 
@@ -26,20 +28,17 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
 
     const { handleSubmit, setError } = editUserForm;
 
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
     const [isPending, startTransition] = useTransition();
 
     const router = useRouter();
 
     const onSubmit = async (data: EditUserFormData) => {
-
         if (!token || !user) return;
-
         startTransition(async () => {
-
             const newData = { ...data };
             const shouldUpdateAvatar = !user.blocked && user.avatar !== data.avatar;
             const shouldUpdateBanner = !user.blocked && user.banner !== data.banner;
-
             try {
 
                 const [avatarPromise, bannerPromise] = [
@@ -66,6 +65,14 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                     shouldUpdateBanner && deleteImage(user.banner)
                 ])
 
+                await Promise.all([
+                    qc.invalidateQueries({ queryKey: ['user', user.username] }),
+                    qc.invalidateQueries({ queryKey: ['history', user.username] }),
+                    qc.invalidateQueries({ queryKey: ['following', token, user.username] }),
+                    qc.invalidateQueries({ queryKey: ['followers', token, user.username] }),
+                    qc.invalidateQueries({ queryKey: ['searchUsers'] }),
+                ])
+
                 editUser(updated);
                 onPortalClose?.();
                 return router.push(`/${data.username}`);
@@ -77,12 +84,8 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(({ closeRef, onPortal
                 ])
                 if (Array.isArray(errors)) handleFieldErrors(errors, setError);
             }
-
         })
-
     }
-
-    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
     if (user) return (
         <FormProvider {...editUserForm}>

--- a/src/core/models/comment/Comment.ts
+++ b/src/core/models/comment/Comment.ts
@@ -1,14 +1,11 @@
-import { Note } from "../note";
 import { User } from "../user";
 import { UUID } from "crypto";
 
 export interface Comment {
     id: UUID,
     user: User | null;
-    note: Note;
     created_at: string;
     text: string;
-    modified_at: string;
     modified: boolean;
     replies_count: number;
 }

--- a/src/core/models/reply/Reply.tsx
+++ b/src/core/models/reply/Reply.tsx
@@ -1,13 +1,10 @@
-import { Comment } from "../comment";
 import { User } from "../user";
 import { UUID } from "crypto";
 
 export interface Reply {
     id: UUID,
     user: User | null;
-    comment: Comment;
     created_at: string;
-    modified_at: string;
     modified: boolean;
     to_user: string | null;
     text: string;

--- a/src/data/contexts/UserContext.tsx
+++ b/src/data/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useCallback, useEffect, useState } from "react";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Token, User, Cookies, shouldUseUserContext } from "@/core";
 import { useFlames, useFollowing, useHistory, useLoading, useNotes, useServices, useStore, useSubscriptions, useTags } from "../hooks";
 import { usePathname } from "next/navigation";
@@ -38,6 +39,7 @@ export const UserProvider = (props: any) => {
 
     const { setIsLoaded } = useLoading();
 
+    const [queryClient] = useState(() => new QueryClient());
     const [state, setState] = useState({
         isMounted: false,
         token: null as Token | null,
@@ -154,7 +156,9 @@ export const UserProvider = (props: any) => {
             setUser,
             clearUser,
         }}>
-            {props.children}
+            <QueryClientProvider client={queryClient}>
+                {props.children}
+            </QueryClientProvider>
         </UserContext.Provider>
     )
 

--- a/src/data/hooks/useAPI.ts
+++ b/src/data/hooks/useAPI.ts
@@ -35,8 +35,7 @@ const handleResponse = async (response: Response) => {
     }
 
     if (response.ok) return data;
-    if (response.status === 404) throw { data, response };
-    throw data;
+    throw { response, data };
 
 }
 

--- a/src/data/hooks/useServices.ts
+++ b/src/data/hooks/useServices.ts
@@ -1,23 +1,32 @@
-import { AuthService, CommentService, FlameService, NoteService, NoteServiceQueries, ReplyService, SponsorshipService, UserService } from "@/services";
+import {
+    AuthService,
+    CommentService,
+    FlameService,
+    NoteService,
+    NoteServiceQueries,
+    ReplyService,
+    SponsorshipService,
+    UserService,
+    UserServiceQueries
+} from "@/services";
 
 export const useServices = () => {
-
     const authService = AuthService();
-
     const userService = UserService();
-
+    const userServiceQueries = UserServiceQueries();
     const noteService = NoteService();
-
     const noteServiceQueries = NoteServiceQueries();
-
     const flameService = FlameService();
-
     const commentService = CommentService();
-
     const replyService = ReplyService();
-
     const sponsorshipService = SponsorshipService();
-
-    return { authService, userService, noteService, noteServiceQueries, flameService, commentService, replyService, sponsorshipService };
-
+    return {
+        authService,
+        userService, userServiceQueries,
+        noteService, noteServiceQueries,
+        flameService,
+        commentService,
+        replyService,
+        sponsorshipService
+    }
 }

--- a/src/data/hooks/useServices.ts
+++ b/src/data/hooks/useServices.ts
@@ -2,6 +2,7 @@ import {
     AuthService,
     CommentService,
     FlameService,
+    FlameServiceQueries,
     NoteService,
     NoteServiceQueries,
     ReplyService,
@@ -17,6 +18,7 @@ export const useServices = () => {
     const noteService = NoteService();
     const noteServiceQueries = NoteServiceQueries();
     const flameService = FlameService();
+    const flameServiceQueries = FlameServiceQueries();
     const commentService = CommentService();
     const replyService = ReplyService();
     const sponsorshipService = SponsorshipService();
@@ -24,7 +26,7 @@ export const useServices = () => {
         authService,
         userService, userServiceQueries,
         noteService, noteServiceQueries,
-        flameService,
+        flameService, flameServiceQueries,
         commentService,
         replyService,
         sponsorshipService

--- a/src/data/hooks/useServices.ts
+++ b/src/data/hooks/useServices.ts
@@ -1,6 +1,7 @@
 import {
     AuthService,
     CommentService,
+    CommentServiceQueries,
     FlameService,
     FlameServiceQueries,
     NoteService,
@@ -20,6 +21,7 @@ export const useServices = () => {
     const flameService = FlameService();
     const flameServiceQueries = FlameServiceQueries();
     const commentService = CommentService();
+    const commentServiceQueries = CommentServiceQueries();
     const replyService = ReplyService();
     const sponsorshipService = SponsorshipService();
     return {
@@ -27,7 +29,7 @@ export const useServices = () => {
         userService, userServiceQueries,
         noteService, noteServiceQueries,
         flameService, flameServiceQueries,
-        commentService,
+        commentService, commentServiceQueries,
         replyService,
         sponsorshipService
     }

--- a/src/data/hooks/useServices.ts
+++ b/src/data/hooks/useServices.ts
@@ -1,4 +1,4 @@
-import { AuthService, CommentService, FlameService, NoteService, ReplyService, SponsorshipService, UserService } from "@/services";
+import { AuthService, CommentService, FlameService, NoteService, NoteServiceQueries, ReplyService, SponsorshipService, UserService } from "@/services";
 
 export const useServices = () => {
 
@@ -8,6 +8,8 @@ export const useServices = () => {
 
     const noteService = NoteService();
 
+    const noteServiceQueries = NoteServiceQueries();
+
     const flameService = FlameService();
 
     const commentService = CommentService();
@@ -16,6 +18,6 @@ export const useServices = () => {
 
     const sponsorshipService = SponsorshipService();
 
-    return { authService, userService, noteService, flameService, commentService, replyService, sponsorshipService };
+    return { authService, userService, noteService, noteServiceQueries, flameService, commentService, replyService, sponsorshipService };
 
 }

--- a/src/data/hooks/useServices.ts
+++ b/src/data/hooks/useServices.ts
@@ -7,6 +7,7 @@ import {
     NoteService,
     NoteServiceQueries,
     ReplyService,
+    ReplyServiceQueries,
     SponsorshipService,
     UserService,
     UserServiceQueries
@@ -23,6 +24,7 @@ export const useServices = () => {
     const commentService = CommentService();
     const commentServiceQueries = CommentServiceQueries();
     const replyService = ReplyService();
+    const replyServiceQueries = ReplyServiceQueries();
     const sponsorshipService = SponsorshipService();
     return {
         authService,
@@ -30,7 +32,7 @@ export const useServices = () => {
         noteService, noteServiceQueries,
         flameService, flameServiceQueries,
         commentService, commentServiceQueries,
-        replyService,
+        replyService, replyServiceQueries,
         sponsorshipService
     }
 }

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -41,7 +41,7 @@ export const AuthService = () => {
     }
 
     const handleExpiredToken = async (error: any, func: (token: string) => Promise<any>) => {
-        if (error.message === 'Token inválido.') {
+        if (error.data.message === 'Token inválido.') {
             const { token } = await refreshUser();
             Cookies.set('rtoken', token.refresh_token, token.expires_at);
             updateToken(token);

--- a/src/services/comment/CommentServiceQueries.ts
+++ b/src/services/comment/CommentServiceQueries.ts
@@ -1,5 +1,5 @@
 import { CommentService } from './CommentService';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfinitePagedQuery } from '../utils';
 import { UUID } from 'crypto';
 
 export const CommentServiceQueries = () => {
@@ -7,14 +7,10 @@ export const CommentServiceQueries = () => {
     const service = CommentService();
 
     const useGetComments = (token: string | null, id: UUID, sort: string, enabled: boolean = true) => {
-        return useInfiniteQuery({
-            queryKey: ['comments', id, sort],
-            queryFn: ({ pageParam }: { pageParam: number }) => service.getComments(token, id, `sort=${sort}&page=${pageParam}`),
-            initialPageParam: 0,
-            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
-            enabled,
-            staleTime: 1000 * 60 * 5,
-            retry: 3
+        return useInfinitePagedQuery({
+            keys: ['comments', token, id, sort],
+            function: (page) => service.getComments(token, id, `sort=${sort}&page=${page}`),
+            enabled
         })
     }
 

--- a/src/services/comment/CommentServiceQueries.ts
+++ b/src/services/comment/CommentServiceQueries.ts
@@ -1,3 +1,4 @@
+import { Comment, Page } from '@/core';
 import { CommentService } from './CommentService';
 import { useInfinitePagedQuery } from '../utils';
 import { UUID } from 'crypto';
@@ -7,7 +8,7 @@ export const CommentServiceQueries = () => {
     const service = CommentService();
 
     const useGetComments = (token: string | null, id: UUID, sort: string, enabled: boolean = true) => {
-        return useInfinitePagedQuery({
+        return useInfinitePagedQuery<Page<Comment>>({
             keys: ['comments', token, id, sort],
             function: (page) => service.getComments(token, id, `sort=${sort}&page=${page}`),
             enabled

--- a/src/services/comment/CommentServiceQueries.ts
+++ b/src/services/comment/CommentServiceQueries.ts
@@ -1,0 +1,23 @@
+import { CommentService } from './CommentService';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { UUID } from 'crypto';
+
+export const CommentServiceQueries = () => {
+
+    const service = CommentService();
+
+    const useGetComments = (token: string | null, id: UUID, sort: string, enabled: boolean = true) => {
+        return useInfiniteQuery({
+            queryKey: ['comments', id, sort],
+            queryFn: ({ pageParam }: { pageParam: number }) => service.getComments(token, id, `sort=${sort}&page=${pageParam}`),
+            initialPageParam: 0,
+            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
+            enabled,
+            staleTime: 1000 * 60 * 5,
+            retry: 3
+        })
+    }
+
+    return { useGetComments };
+
+}

--- a/src/services/comment/index.ts
+++ b/src/services/comment/index.ts
@@ -1,3 +1,4 @@
 import { CommentService } from "./CommentService";
+import { CommentServiceQueries } from "./CommentServiceQueries";
 
-export { CommentService };
+export { CommentService, CommentServiceQueries };

--- a/src/services/flame/FlameServiceQueries.ts
+++ b/src/services/flame/FlameServiceQueries.ts
@@ -1,0 +1,24 @@
+import { customQueryFn, customRetry } from '../utils';
+import { FlameService } from './FlameService';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+export const FlameServiceQueries = () => {
+
+    const service = FlameService();
+
+    const useSearchUserFlames = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['flames', username, parameters],
+            queryFn: customQueryFn(() => service.searchUserFlames(token, username, parameters)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: customRetry
+        })
+    }
+
+    return {
+        useSearchUserFlames
+    }
+
+}

--- a/src/services/flame/FlameServiceQueries.ts
+++ b/src/services/flame/FlameServiceQueries.ts
@@ -1,24 +1,18 @@
-import { customQueryFn, customRetry } from '../utils';
 import { FlameService } from './FlameService';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useGuardedQuery } from '../utils';
 
 export const FlameServiceQueries = () => {
 
     const service = FlameService();
 
     const useSearchUserFlames = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['flames', username, parameters],
-            queryFn: customQueryFn(() => service.searchUserFlames(token, username, parameters)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['flames', token, username, parameters],
+            function: () => service.searchUserFlames(token, username, parameters),
+            enabled: enabled
         })
     }
 
-    return {
-        useSearchUserFlames
-    }
+    return { useSearchUserFlames };
 
 }

--- a/src/services/flame/index.ts
+++ b/src/services/flame/index.ts
@@ -1,1 +1,2 @@
 export { FlameService } from "./FlameService";
+export { FlameServiceQueries } from "./FlameServiceQueries";

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,33 +1,11 @@
+import { customQueryFn, customRetry } from '../utils';
 import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { NoteService } from './NoteService';
 import { UUID } from 'crypto';
 
-type CustomResponse =
-    | { type: 'ok', data: any }
-    | { type: 'notfound', data: any }
-    | { type: 'forbidden', data: any }
-
 export const NoteServiceQueries = () => {
 
     const service = NoteService();
-
-    const customQueryFn = (fn: () => Promise<any>) => {
-        return async (): Promise<CustomResponse> => {
-            try {
-                const data = await fn();
-                return { type: 'ok', data };
-            } catch (error: any) {
-                if (error.response.status === 403) return { type: 'forbidden', data: error.data };
-                if (error.response.status === 404) return { type: 'notfound', data: error.data };
-                throw error;
-            }
-        }
-    }
-
-    const smartRetry = (failureCount: number, error: any) => {
-        if (error.response.status < 500) return false;
-        return failureCount < 3;
-    }
 
     const useGetFeed = (token: string, enabled: boolean = true) => {
         return useInfiniteQuery({
@@ -48,7 +26,7 @@ export const NoteServiceQueries = () => {
             enabled: enabled,
             staleTime: 1000 * 60 * 5,
             placeholderData: keepPreviousData,
-            retry: smartRetry
+            retry: customRetry
         })
     }
 
@@ -59,7 +37,7 @@ export const NoteServiceQueries = () => {
             enabled: enabled,
             staleTime: 1000 * 60 * 5,
             placeholderData: keepPreviousData,
-            retry: smartRetry
+            retry: customRetry
         })
     }
 
@@ -92,7 +70,7 @@ export const NoteServiceQueries = () => {
             enabled: enabled,
             staleTime: 1000 * 60 * 5,
             placeholderData: keepPreviousData,
-            retry: smartRetry
+            retry: customRetry
         })
     }
 

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,6 +1,5 @@
-import { customQueryFn, customRetry } from '../utils';
-import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { NoteService } from './NoteService';
+import { useGuardedQuery, useInfinitePagedQuery, usePublicQuery } from '../utils';
 import { UUID } from 'crypto';
 
 export const NoteServiceQueries = () => {
@@ -8,69 +7,50 @@ export const NoteServiceQueries = () => {
     const service = NoteService();
 
     const useGetFeed = (token: string, enabled: boolean = true) => {
-        return useInfiniteQuery({
-            queryKey: ['feed'],
-            queryFn: ({ pageParam = 0 }: { pageParam: number }) => service.getFeedNotes(token, `page=${pageParam}`),
-            initialPageParam: 0,
-            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            retry: 3
+        return useInfinitePagedQuery({
+            keys: ['feed', token],
+            function: (page) => service.getFeedNotes(token, `page=${page}`),
+            enabled: enabled
         })
     }
 
     const useFindUserTags = (token: string | null, username: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['userTags', username],
-            queryFn: customQueryFn(() => service.findUserTags(token, username)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['userTags', token, username],
+            function: () => service.findUserTags(token, username),
+            enabled: enabled
         })
     }
 
     const useFindUserNotes = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['userNotes', username, parameters],
-            queryFn: customQueryFn(() => service.searchUserNotes(token, username, parameters)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['userNotes', token, username, parameters],
+            function: () => service.searchUserNotes(token, username, parameters),
+            enabled: enabled
         })
     }
 
     const useSearchNotes = (parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['searchNotes', parameters],
-            queryFn: () => service.searchNotes(parameters),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: 3
+        return usePublicQuery({
+            keys: ['searchNotes', parameters],
+            function: () => service.searchNotes(parameters),
+            enabled: enabled
         })
     }
 
     const useSearchTags = (parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['searchTags', parameters],
-            queryFn: () => service.searchTags(parameters),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: 3
+        return usePublicQuery({
+            keys: ['searchTags', parameters],
+            function: () => service.searchTags(parameters),
+            enabled: enabled
         })
     }
 
     const useGetNote = (token: string | null, id: UUID, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['note', id],
-            queryFn: customQueryFn(() => service.getNote(token, id)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['note', token, id],
+            function: () => service.getNote(token, id),
+            enabled: enabled
         })
     }
 

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,3 +1,4 @@
+import { LowDetailNote, Page } from '@/core';
 import { NoteService } from './NoteService';
 import { useGuardedQuery, useInfinitePagedQuery, usePublicQuery } from '../utils';
 import { UUID } from 'crypto';
@@ -7,7 +8,7 @@ export const NoteServiceQueries = () => {
     const service = NoteService();
 
     const useGetFeed = (token: string, enabled: boolean = true) => {
-        return useInfinitePagedQuery({
+        return useInfinitePagedQuery<Page<LowDetailNote>>({
             keys: ['feed', token],
             function: (page) => service.getFeedNotes(token, `page=${page}`),
             enabled: enabled

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,0 +1,58 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { NoteService } from './NoteService';
+
+type CustomResponse =
+    | { type: 'ok', data: any }
+    | { type: 'notfound', data: any }
+    | { type: 'forbidden', data: any }
+
+export const NoteServiceQueries = () => {
+
+    const service = NoteService();
+
+    const customQueryFn = (fn: () => Promise<any>) => {
+        return async (): Promise<CustomResponse> => {
+            try {
+                const data = await fn();
+                return { type: 'ok', data };
+            } catch (error: any) {
+                if (error.response.status === 403) return { type: 'forbidden', data: error.data };
+                if (error.response.status === 404) return { type: 'notfound', data: error.data };
+                throw error;
+            }
+        }
+    }
+
+    const smartRetry = (failureCount: number, error: any) => {
+        if (error.response.status < 500) return false;
+        return failureCount < 3;
+    }
+
+    const useFindUserTags = (token: string | null, username: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['userTags', username],
+            queryFn: customQueryFn(() => service.findUserTags(token, username)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: smartRetry
+        })
+    }
+
+    const useFindUserNotes = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['userNotes', username, parameters],
+            queryFn: customQueryFn(() => service.searchUserNotes(token, username, parameters)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: smartRetry
+        })
+    }
+
+    return {
+        useFindUserTags,
+        useFindUserNotes
+    }
+
+}

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -62,10 +62,34 @@ export const NoteServiceQueries = () => {
         })
     }
 
+    const useSearchNotes = (parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['searchNotes', parameters],
+            queryFn: () => service.searchNotes(parameters),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: 3
+        })
+    }
+
+    const useSearchTags = (parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['searchTags', parameters],
+            queryFn: () => service.searchTags(parameters),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: 3
+        })
+    }
+
     return {
         useFindUserTags,
         useFindUserNotes,
-        useGetFeed
+        useGetFeed,
+        useSearchNotes,
+        useSearchTags
     }
 
 }

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { NoteService } from './NoteService';
 
 type CustomResponse =
@@ -28,6 +28,18 @@ export const NoteServiceQueries = () => {
         return failureCount < 3;
     }
 
+    const useGetFeed = (token: string, enabled: boolean = true) => {
+        return useInfiniteQuery({
+            queryKey: ['feed'],
+            queryFn: ({ pageParam = 0 }: { pageParam: number }) => service.getFeedNotes(token, `page=${pageParam}`),
+            initialPageParam: 0,
+            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            retry: 3
+        })
+    }
+
     const useFindUserTags = (token: string | null, username: string, enabled: boolean = true) => {
         return useQuery({
             queryKey: ['userTags', username],
@@ -52,7 +64,8 @@ export const NoteServiceQueries = () => {
 
     return {
         useFindUserTags,
-        useFindUserNotes
+        useFindUserNotes,
+        useGetFeed
     }
 
 }

--- a/src/services/note/NoteServiceQueries.ts
+++ b/src/services/note/NoteServiceQueries.ts
@@ -1,5 +1,6 @@
 import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { NoteService } from './NoteService';
+import { UUID } from 'crypto';
 
 type CustomResponse =
     | { type: 'ok', data: any }
@@ -84,12 +85,24 @@ export const NoteServiceQueries = () => {
         })
     }
 
+    const useGetNote = (token: string | null, id: UUID, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['note', id],
+            queryFn: customQueryFn(() => service.getNote(token, id)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: smartRetry
+        })
+    }
+
     return {
         useFindUserTags,
         useFindUserNotes,
         useGetFeed,
         useSearchNotes,
-        useSearchTags
+        useSearchTags,
+        useGetNote
     }
 
 }

--- a/src/services/note/index.ts
+++ b/src/services/note/index.ts
@@ -1,3 +1,4 @@
 import { NoteService } from "./NoteService";
+import { NoteServiceQueries } from './NoteServiceQueries';
 
-export { NoteService };
+export { NoteService, NoteServiceQueries };

--- a/src/services/reply/ReplyService.ts
+++ b/src/services/reply/ReplyService.ts
@@ -36,7 +36,7 @@ export const ReplyService = () => {
         }
     }
 
-    const editReply = async (token: string, id: UUID, data: CreateReplyFormData): Promise<Reply> => {
+    const editReply = async (token: string, id: UUID, data: CreateReplyFormData): Promise<void> => {
         const endpoint = `/notes/comments/replies/${id}/edit`;
         try {
             return await httpPatch(endpoint, data, { useToken: token });
@@ -45,7 +45,7 @@ export const ReplyService = () => {
         }
     }
 
-    const deleteReply = async (token: string, id: UUID) => {
+    const deleteReply = async (token: string, id: UUID): Promise<void> => {
         const endpoint = `/notes/comments/replies/${id}/delete`;
         try {
             return await httpDelete(endpoint, undefined, { useToken: token });

--- a/src/services/reply/ReplyServiceQueries.ts
+++ b/src/services/reply/ReplyServiceQueries.ts
@@ -1,0 +1,23 @@
+import { ReplyService } from './ReplyService';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { UUID } from 'crypto';
+
+export const ReplyServiceQueries = () => {
+
+    const service = ReplyService();
+
+    const useGetReplies = (token: string | null, id: UUID, enabled: boolean = true) => {
+        return useInfiniteQuery({
+            queryKey: ['replies', id],
+            queryFn: ({ pageParam }: { pageParam: number }) => service.getReplies(token, id, `page=${pageParam}`),
+            initialPageParam: 0,
+            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            retry: 3
+        })
+    }
+
+    return { useGetReplies };
+
+}

--- a/src/services/reply/ReplyServiceQueries.ts
+++ b/src/services/reply/ReplyServiceQueries.ts
@@ -1,5 +1,5 @@
 import { ReplyService } from './ReplyService';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfinitePagedQuery } from '../utils';
 import { UUID } from 'crypto';
 
 export const ReplyServiceQueries = () => {
@@ -7,14 +7,10 @@ export const ReplyServiceQueries = () => {
     const service = ReplyService();
 
     const useGetReplies = (token: string | null, id: UUID, enabled: boolean = true) => {
-        return useInfiniteQuery({
-            queryKey: ['replies', id],
-            queryFn: ({ pageParam }: { pageParam: number }) => service.getReplies(token, id, `page=${pageParam}`),
-            initialPageParam: 0,
-            getNextPageParam: (page, _, pageParam) => page.last ? undefined : pageParam + 1,
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            retry: 3
+        return useInfinitePagedQuery({
+            keys: ['replies', token, id],
+            function: (page) => service.getReplies(token, id, `page=${page}`),
+            enabled: enabled
         })
     }
 

--- a/src/services/reply/ReplyServiceQueries.ts
+++ b/src/services/reply/ReplyServiceQueries.ts
@@ -1,3 +1,4 @@
+import { Page, Reply } from '@/core';
 import { ReplyService } from './ReplyService';
 import { useInfinitePagedQuery } from '../utils';
 import { UUID } from 'crypto';
@@ -7,7 +8,7 @@ export const ReplyServiceQueries = () => {
     const service = ReplyService();
 
     const useGetReplies = (token: string | null, id: UUID, enabled: boolean = true) => {
-        return useInfinitePagedQuery({
+        return useInfinitePagedQuery<Page<Reply>>({
             keys: ['replies', token, id],
             function: (page) => service.getReplies(token, id, `page=${page}`),
             enabled: enabled

--- a/src/services/reply/index.ts
+++ b/src/services/reply/index.ts
@@ -1,3 +1,4 @@
 import { ReplyService } from "./ReplyService";
+import { ReplyServiceQueries } from "./ReplyServiceQueries";
 
-export { ReplyService };
+export { ReplyService, ReplyServiceQueries };

--- a/src/services/user/UserServiceQueries.ts
+++ b/src/services/user/UserServiceQueries.ts
@@ -1,0 +1,23 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { UserService } from './UserService';
+
+export const UserServiceQueries = () => {
+
+    const service = UserService();
+
+    const useSearchUsers = (parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['searchUsers', parameters],
+            queryFn: () => service.searchUsers(parameters),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: 3
+        })
+    }
+
+    return {
+        useSearchUsers
+    }
+
+}

--- a/src/services/user/UserServiceQueries.ts
+++ b/src/services/user/UserServiceQueries.ts
@@ -1,9 +1,34 @@
+import { customQueryFn, customRetry } from '../utils';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { UserService } from './UserService';
 
 export const UserServiceQueries = () => {
 
     const service = UserService();
+
+    // searchUserFollowing searchUserFollowers
+
+    const useGetUser = (username: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['user', username],
+            queryFn: customQueryFn(() => service.getUser(username)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: customRetry
+        })
+    }
+
+    const useGetUserDisplayNameHistory = (username: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['getUserDisplayNameHistory', username],
+            queryFn: customQueryFn(() => service.getUserDisplayNameHistory(username)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: customRetry
+        })
+    }
 
     const useSearchUsers = (parameters?: string, enabled: boolean = true) => {
         return useQuery({
@@ -17,6 +42,8 @@ export const UserServiceQueries = () => {
     }
 
     return {
+        useGetUser,
+        useGetUserDisplayNameHistory,
         useSearchUsers
     }
 

--- a/src/services/user/UserServiceQueries.ts
+++ b/src/services/user/UserServiceQueries.ts
@@ -1,5 +1,4 @@
-import { customQueryFn, customRetry } from '../utils';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useGuardedQuery, usePublicQuery } from '../utils';
 import { UserService } from './UserService';
 
 export const UserServiceQueries = () => {
@@ -7,57 +6,42 @@ export const UserServiceQueries = () => {
     const service = UserService();
 
     const useGetUser = (username: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['user', username],
-            queryFn: customQueryFn(() => service.getUser(username)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['user', username],
+            function: () => service.getUser(username),
+            enabled: enabled
         })
     }
 
     const useGetUserDisplayNameHistory = (username: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['history', username],
-            queryFn: customQueryFn(() => service.getUserDisplayNameHistory(username)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['history', username],
+            function: () => service.getUserDisplayNameHistory(username),
+            enabled: enabled
         })
     }
 
     const useSearchUsers = (parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['searchUsers', parameters],
-            queryFn: () => service.searchUsers(parameters),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: 3
+        return usePublicQuery({
+            keys: ['searchUsers', parameters],
+            function: () => service.searchUsers(parameters),
+            enabled: enabled
         })
     }
 
     const useSearchUserFollowing = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['following', username, parameters],
-            queryFn: customQueryFn(() => service.searchUserFollowing(token, username, parameters)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['following', token, username, parameters],
+            function: () => service.searchUserFollowing(token, username, parameters),
+            enabled: enabled
         })
     }
 
     const useSearchUserFollowers = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
-        return useQuery({
-            queryKey: ['followers', username, parameters],
-            queryFn: customQueryFn(() => service.searchUserFollowers(token, username, parameters)),
-            enabled: enabled,
-            staleTime: 1000 * 60 * 5,
-            placeholderData: keepPreviousData,
-            retry: customRetry
+        return useGuardedQuery({
+            keys: ['followers', token, username, parameters],
+            function: () => service.searchUserFollowers(token, username, parameters),
+            enabled: enabled
         })
     }
 

--- a/src/services/user/UserServiceQueries.ts
+++ b/src/services/user/UserServiceQueries.ts
@@ -6,8 +6,6 @@ export const UserServiceQueries = () => {
 
     const service = UserService();
 
-    // searchUserFollowing searchUserFollowers
-
     const useGetUser = (username: string, enabled: boolean = true) => {
         return useQuery({
             queryKey: ['user', username],
@@ -21,7 +19,7 @@ export const UserServiceQueries = () => {
 
     const useGetUserDisplayNameHistory = (username: string, enabled: boolean = true) => {
         return useQuery({
-            queryKey: ['getUserDisplayNameHistory', username],
+            queryKey: ['history', username],
             queryFn: customQueryFn(() => service.getUserDisplayNameHistory(username)),
             enabled: enabled,
             staleTime: 1000 * 60 * 5,
@@ -41,10 +39,34 @@ export const UserServiceQueries = () => {
         })
     }
 
+    const useSearchUserFollowing = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['following', username, parameters],
+            queryFn: customQueryFn(() => service.searchUserFollowing(token, username, parameters)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: customRetry
+        })
+    }
+
+    const useSearchUserFollowers = (token: string | null, username: string, parameters?: string, enabled: boolean = true) => {
+        return useQuery({
+            queryKey: ['followers', username, parameters],
+            queryFn: customQueryFn(() => service.searchUserFollowers(token, username, parameters)),
+            enabled: enabled,
+            staleTime: 1000 * 60 * 5,
+            placeholderData: keepPreviousData,
+            retry: customRetry
+        })
+    }
+
     return {
         useGetUser,
         useGetUserDisplayNameHistory,
-        useSearchUsers
+        useSearchUsers,
+        useSearchUserFollowing,
+        useSearchUserFollowers
     }
 
 }

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,3 +1,4 @@
 import { UserService } from "./UserService";
+import { UserServiceQueries } from "./UserServiceQueries";
 
-export { UserService };
+export { UserService, UserServiceQueries };

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,0 +1,26 @@
+import FieldError from '@/core/utils/FieldError';
+
+type CustomResponse<T> =
+    | { type: 'ok', data: T }
+    | { type: 'notfound', data: FieldError[] }
+    | { type: 'forbidden', data: FieldError[] }
+
+const customQueryFn = <T>(fn: () => Promise<T>) => {
+    return async (): Promise<CustomResponse<T>> => {
+        try {
+            const data = await fn();
+            return { type: 'ok', data };
+        } catch (error: any) {
+            if (error.response.status === 403) return { type: 'forbidden', data: error.data };
+            if (error.response.status === 404) return { type: 'notfound', data: error.data };
+            throw error;
+        }
+    }
+}
+
+const customRetry = (failureCount: number, error: any) => {
+    if (error.response.status < 500) return false;
+    return failureCount < 3;
+}
+
+export { customQueryFn, customRetry };

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,12 +1,28 @@
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import FieldError from '@/core/utils/FieldError';
 
-type CustomResponse<T> =
+type QueryInput<T> = {
+    keys: unknown[];
+    function: () => Promise<T>;
+    enabled?: boolean;
+}
+
+type PagedResponse = { last: boolean };
+type InfiniteQueryInput<T extends PagedResponse> = {
+    keys: unknown[];
+    function: (pageParam: number) => Promise<T>;
+    enabled?: boolean;
+}
+
+type QueryResponse<T> =
     | { type: 'ok', data: T }
     | { type: 'notfound', data: FieldError[] }
     | { type: 'forbidden', data: FieldError[] }
 
+const STALE_TIME = 1000 * 60 * 5;
+
 const customQueryFn = <T>(fn: () => Promise<T>) => {
-    return async (): Promise<CustomResponse<T>> => {
+    return async (): Promise<QueryResponse<T>> => {
         try {
             const data = await fn();
             return { type: 'ok', data };
@@ -23,4 +39,45 @@ const customRetry = (failureCount: number, error: any) => {
     return failureCount < 3;
 }
 
-export { customQueryFn, customRetry };
+const usePublicQuery = <T>({ keys, function: fn, enabled = true }: QueryInput<T>) => {
+    return useQuery({
+        queryKey: keys,
+        queryFn: fn,
+        enabled,
+        placeholderData: keepPreviousData,
+        refetchOnWindowFocus: false,
+        staleTime: STALE_TIME,
+        retry: 3
+    })
+}
+
+const useGuardedQuery = <T>({ keys, function: fn, enabled = true }: QueryInput<T>) => {
+    return useQuery({
+        queryKey: keys,
+        queryFn: customQueryFn(fn),
+        enabled,
+        placeholderData: keepPreviousData,
+        refetchOnWindowFocus: false,
+        staleTime: STALE_TIME,
+        retry: customRetry
+    })
+}
+
+const useInfinitePagedQuery = <T extends PagedResponse>({ keys, function: fn, enabled = true }: InfiniteQueryInput<T>) => {
+    return useInfiniteQuery({
+        queryKey: keys,
+        queryFn: ({ pageParam }: { pageParam: number }) => fn(pageParam),
+        initialPageParam: 0,
+        getNextPageParam: (page: T, _, pageParam) => page.last ? undefined : pageParam + 1,
+        enabled,
+        staleTime: STALE_TIME,
+        refetchOnWindowFocus: false,
+        retry: 3
+    });
+}
+
+export {
+    usePublicQuery,
+    useGuardedQuery,
+    useInfinitePagedQuery
+}

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,4 +1,5 @@
 import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { Page } from '@/core';
 import FieldError from '@/core/utils/FieldError';
 
 type QueryInput<T> = {
@@ -7,8 +8,7 @@ type QueryInput<T> = {
     enabled?: boolean;
 }
 
-type PagedResponse = { last: boolean };
-type InfiniteQueryInput<T extends PagedResponse> = {
+type InfiniteQueryInput<T extends Page<unknown>> = {
     keys: unknown[];
     function: (pageParam: number) => Promise<T>;
     enabled?: boolean;
@@ -63,7 +63,7 @@ const useGuardedQuery = <T>({ keys, function: fn, enabled = true }: QueryInput<T
     })
 }
 
-const useInfinitePagedQuery = <T extends PagedResponse>({ keys, function: fn, enabled = true }: InfiniteQueryInput<T>) => {
+const useInfinitePagedQuery = <T extends Page<unknown>>({ keys, function: fn, enabled = true }: InfiniteQueryInput<T>) => {
     return useInfiniteQuery({
         queryKey: keys,
         queryFn: ({ pageParam }: { pageParam: number }) => fn(pageParam),
@@ -73,7 +73,7 @@ const useInfinitePagedQuery = <T extends PagedResponse>({ keys, function: fn, en
         staleTime: STALE_TIME,
         refetchOnWindowFocus: false,
         retry: 3
-    });
+    })
 }
 
 export {


### PR DESCRIPTION
### Sumário

Migração completa do sistema de fetching de dados para **React Query** (`@tanstack/react-query`), substituindo a lógica manual de fetch em todos os módulos do cliente.

### Motivação

A lógica manual de fetch espalhada pelos módulos não oferecia suporte a cache, fazendo com que requisições redundantes fossem disparadas repetidamente para os mesmos dados. A adoção do React Query introduz uma camada de cache automático, reduzindo o número de requisições e melhorando a performance percebida pelo usuário.

### Alterações

- Adicionada dependência `@tanstack/react-query`
- Corrigidos campos com divergência em relação ao backend e adicionadas tipagens explícitas em `types`
- Substituída a lógica manual de fetch por hooks do React Query nos módulos: `feed`, `search`, `note`, `notes-specs`, `flames-specs`, `user`, `follows`, `comments` e `replies`
- Abstraídos hooks de query compartilhados e adicionado token às query keys
- Implementada invalidação de cache nas operações de escrita dos módulos: `user`, `note`, `comment`, `flame` e `follow`
- Adicionada sincronização do cache de queries após operações de escrita em `reply`

### Teste manual

1. Navegar pelas rotas que disparam requisições de leitura (feed, perfil, nota, comentários etc.) e repeti-las — na segunda visita, os dados devem ser servidos do cache sem novas requisições à API
2. Executar operações de escrita (criar, editar ou excluir recursos) e navegar novamente pelas rotas relacionadas — o cache deve ter sido invalidado e uma nova requisição deve ser disparada, refletindo os dados atualizados

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
* *Nenhuma*