### PR TITLE
feat(ui): shimmer animation on skeleton bone and scope badge on release title

### DIFF
--- a/src/app/(pages)/changelog/elements/ReleaseTitle.tsx
+++ b/src/app/(pages)/changelog/elements/ReleaseTitle.tsx
@@ -1,3 +1,4 @@
+import { clsx } from 'clsx';
 import Link from "next/link";
 
 interface ReleaseTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -17,5 +18,12 @@ export const ReleaseTitle = ({ scope, tag, children, ...rest }: ReleaseTitleProp
             {tag.replace('v', '')}
         </Link>
         <span className="ml-3">{children}</span>
+        <span className={clsx(
+            'align-middle ml-3 px-1 py-0.5 rounded',
+            'uppercase tracking-wider text-xs dark:text-lighter text-darker ',
+            'dark:bg-lighter/15 bg-darker/15'
+        )}>
+            {scope}
+        </span>
     </h2>
 )

--- a/src/components/Bone.tsx
+++ b/src/components/Bone.tsx
@@ -13,6 +13,13 @@ export const Bone = ({ width, height, rounded, className, ...rest }: Bone) => {
             style={{ width: `${width}px`, height: `${height}px` }}
             className={clsx(
                 `rounded-${rounded}`,
+                'relative overflow-hidden',
+                'after:absolute after:inset-0',
+                'after:-translate-x-full',
+                'after:bg-gradient-to-r',
+                'after:dark:from-transparent after:dark:via-light/15 after:dark:to-transparent',
+                'after:from-transparent after:via-dark/15 after:to-transparent',
+                'after:animate-shiny',
                 'dark:bg-dark bg-light dark:drop-shadow-alpha-l-sm drop-shadow-alpha-d-sm',
                 className
             )}


### PR DESCRIPTION
### Sumário
Adição de animação de brilho ao componente que compõe o esqueleto de carregamento e rótulo de escopo ao título do lançamento no registro de alterações.

### Motivação
Melhorar o feedback visual durante carregamentos e tornar o scope de cada release explícito na interface.

### Alterações
- `Bone`: animação shimmer via pseudo-elemento `::after` com gradiente deslizante
- `ReleaseTitle`: badge com o valor de `scope` da release

### Teste manual
1. Verificar se a animação shimmer aparece nos skeletons de loading
2. Verificar se o badge de scope aparece corretamente no changelog para os três valores: `server`, `client` e `server & client`

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
* *Nenhuma*