### PR TITLE
feat(auth): allow login with email or username

### DIFF
--- a/src/components/forms/auth/signin/elements/Error.tsx
+++ b/src/components/forms/auth/signin/elements/Error.tsx
@@ -1,8 +1,9 @@
+import { LoginFormData } from '@/core';
 import { useFormContext } from "react-hook-form";
 
 interface ErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {
-    field: string;
-};
+    field: keyof LoginFormData;
+}
 
 const Error = ({ field, ...rest }: ErrorProps) => {
 
@@ -17,6 +18,7 @@ const Error = ({ field, ...rest }: ErrorProps) => {
             {error.toString()}
         </p>
     )
-};
+
+}
 
 export default Error;

--- a/src/components/forms/auth/signin/elements/Input.tsx
+++ b/src/components/forms/auth/signin/elements/Input.tsx
@@ -1,11 +1,12 @@
 import { IconEye, IconEyeClosed } from "@tabler/icons-react";
 import { InputHTMLAttributes, useState } from "react";
+import { LoginFormData } from '@/core';
 import { useFormContext } from "react-hook-form";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-    name: string;
+    name: keyof LoginFormData;
     icon?: React.ReactNode;
-};
+}
 
 const Input = ({ name, icon, type = "text", ...rest }: InputProps) => {
 
@@ -67,8 +68,8 @@ const Input = ({ name, icon, type = "text", ...rest }: InputProps) => {
                 </button>
             }
         </div>
-    );
+    )
 
-};
+}
 
 export default Input;

--- a/src/components/forms/auth/signin/elements/Label.tsx
+++ b/src/components/forms/auth/signin/elements/Label.tsx
@@ -1,14 +1,16 @@
-import { LabelHTMLAttributes } from "react";
 import { IconQuestionMark } from "@tabler/icons-react";
+import { LabelHTMLAttributes } from "react";
+import { LoginFormData } from '@/core';
 
 interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+    htmlFor: keyof LoginFormData;
     tooltip?: React.ReactNode;
 }
 
-const Label = ({ tooltip, ...rest }: LabelProps) => {
+const Label = ({ htmlFor, tooltip, ...rest }: LabelProps) => {
     return (
         <div className="flex items-center gap-1 px-1 ">
-            <label className="text-md dark:text-slate-100 text-dark" {...rest} />
+            <label htmlFor={htmlFor} className="text-md dark:text-slate-100 text-dark" {...rest} />
             {tooltip &&
                 <div className="group relative">
                     <IconQuestionMark size={17} className="text-slate-100 rounded-full dark:bg-slate-300/50 bg-neutral-500" />
@@ -26,6 +28,6 @@ const Label = ({ tooltip, ...rest }: LabelProps) => {
                 </div>}
         </div>
     )
-};
+}
 
 export default Label;

--- a/src/components/forms/auth/signin/index.tsx
+++ b/src/components/forms/auth/signin/index.tsx
@@ -107,9 +107,9 @@ export const Form = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
             >
                 <Element.Header />
                 <Element.Field>
-                    <Element.Label htmlFor="username">Usuário</Element.Label>
-                    <Element.Input name="username" type="text" required icon={<IconAt title="@" />} />
-                    <Element.Error field="username" />
+                    <Element.Label htmlFor="identifier">Usuário ou email</Element.Label>
+                    <Element.Input name="identifier" type="text" required icon={<IconAt title="@" />} />
+                    <Element.Error field="identifier" />
                 </Element.Field>
                 <Element.Field>
                     <Element.Label htmlFor="password">Senha</Element.Label>

--- a/src/core/schemas/auth/Login.ts
+++ b/src/core/schemas/auth/Login.ts
@@ -2,15 +2,14 @@ import { noForbiddenWords } from '@/core/utils';
 import { z } from 'zod';
 
 export const loginFormSchema = z.object({
-    username: noForbiddenWords("Não pode")(z
+    identifier: noForbiddenWords("Não pode")(z
         .string().trim().toLowerCase()
-        .regex(/^[a-zA-Z0-9_.-]+$/, "Use letras, números, _, . ou -")
         .min(2, 'Mínimo de 2 caracteres.')
-        .max(12, 'Máximo de 12 caracteres.')),
+        .max(255, 'Máximo de 255 caracteres.')),
     password: z
         .string().trim()
         .min(4, 'Mínimo de 4 caracteres.')
         .max(255, 'Máximo de 255 caracteres.'),
-});
+})
 
 export type LoginFormData = z.infer<typeof loginFormSchema>;


### PR DESCRIPTION
### Sumário

Substituição do campo `username` por `identifier` no formulário de login, permitindo que o usuário autentique com e-mail ou username.

### Alterações

- `Login.ts`: campo `username` renomeado para `identifier`, removida a regex restritiva de username e aumentado o `max` para 255 caracteres

### Necessidade

Alinhamento com a mudança no backend que passou a aceitar e-mail ou username como identificador de autenticação. Anteriormente o formulário enviava apenas `username`, quebrando a integração com o novo contrato da API.

### Teste manual

1. Realizar login com um **username** válido
2. Realizar login com um **e-mail** válido
3. Tentar login com identificador inexistente — esperar erro `401`
4. Tentar login com senha incorreta — esperar erro `401`
5. Verificar mensagens de validação do formulário com campos vazios ou muito curtos

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
- **Nenhuma**