### PR TITLE
feat(user): add dev badge to user

### DIFF
--- a/src/app/(pages)/[username]/components/desktop/layout/Title.tsx
+++ b/src/app/(pages)/[username]/components/desktop/layout/Title.tsx
@@ -46,7 +46,10 @@ export const Title = ({ user, history, ...rest }: TitleProps) => {
                 {...rest}
             >
 
-                <Icon.Sponsor user={user} size={25} />
+                {user.dev
+                    ? <Icon.Dev user={user} size={25} />
+                    : <Icon.Sponsor user={user} size={25} />
+                }
                 {user.display_name}
                 {history.length > 0 &&
                     <span

--- a/src/app/(pages)/[username]/components/mobile/Header.tsx
+++ b/src/app/(pages)/[username]/components/mobile/Header.tsx
@@ -40,7 +40,10 @@ export const Header = ({ user, ...rest }: { user: User | LowDetailUser } & React
                 }
                 <div className="w-full px-3 overflow-hidden flex items-center justify-center gap-3">
                     <Layout.Title>
-                        <Icon.Sponsor user={user} size={25} />
+                        {user.dev
+                            ? <Icon.Dev user={user} size={25} />
+                            : <Icon.Sponsor user={user} size={25} />
+                        }
                         {user.display_name}
                     </Layout.Title>
                     {isCurrentUserProfile &&

--- a/src/app/(pages)/[username]/flames/elements/main/index.tsx
+++ b/src/app/(pages)/[username]/flames/elements/main/index.tsx
@@ -22,7 +22,11 @@ export const Main = ({ flames, ...rest }: MainProps) => {
                         <header className="relative pl-14 flex flex-col gap-1">
                             <Photo user={flame.note.user} size={44} className="absolute top-0 left-0" />
                             <PlainText className={`flex gap-1 ${!flame.note.user && 'line-through'}`}>
-                                {flame.note.user && <Icon.Sponsor user={flame.note.user} size={24} />}
+                                {flame.note.user && (
+                                    flame.note.user.dev
+                                        ? <Icon.Dev user={flame.note.user} size={24} />
+                                        : <Icon.Sponsor user={flame.note.user} size={24} />
+                                )}
                                 {flame.note.user ? flame.note.user.display_name : 'Deletado'}
                             </PlainText>
                             <Time flame={flame} />

--- a/src/app/(pages)/[username]/followers/elements/main/elements/User.tsx
+++ b/src/app/(pages)/[username]/followers/elements/main/elements/User.tsx
@@ -20,7 +20,7 @@ export const User = ({ user, ...rest }: UserProps) => (
             dark:bg-lighter/30 bg-darker/30
             backdrop-blur moz:backdrop-blur-none"
         >
-            <Icon.Sponsor user={user} size={24} />
+            {user.dev ? <Icon.Dev user={user} size={24} /> : <Icon.Sponsor user={user} size={24} />}
             <span
                 className="truncate group-hover/user:underline
                 text-sm decoration-2 text-white

--- a/src/app/(pages)/[username]/following/elements/main/elements/User.tsx
+++ b/src/app/(pages)/[username]/following/elements/main/elements/User.tsx
@@ -20,7 +20,7 @@ export const User = ({ user, ...rest }: UserProps) => (
             dark:bg-lighter/30 bg-darker/30
             backdrop-blur moz:backdrop-blur-none"
         >
-            <Icon.Sponsor user={user} size={24} />
+            {user.dev ? <Icon.Dev user={user} size={24} /> : <Icon.Sponsor user={user} size={24} />}
             <span
                 className="truncate group-hover/user:underline
                 text-sm decoration-2 text-white

--- a/src/app/(pages)/[username]/notes/elements/main/index.tsx
+++ b/src/app/(pages)/[username]/notes/elements/main/index.tsx
@@ -22,7 +22,11 @@ export const Main = ({ notes, ...rest }: MainProps) => {
                         <header className="relative pl-14 flex flex-col gap-1">
                             <Photo user={note.user} size={44} className="absolute top-0 left-0" />
                             <PlainText className={`flex gap-1 ${!note.user && 'line-through'}`}>
-                                {note.user && <Icon.Sponsor user={note.user} size={24} />}
+                                {note.user && (
+                                    note.user.dev
+                                        ? <Icon.Dev user={note.user} size={24} />
+                                        : <Icon.Sponsor user={note.user} size={24} />
+                                )}
                                 {note.user ? note.user.display_name : 'Deletado'}
                             </PlainText>
                             <Time note={note} />

--- a/src/app/(pages)/dashboard/user/aside/changelog/index.tsx
+++ b/src/app/(pages)/dashboard/user/aside/changelog/index.tsx
@@ -20,7 +20,7 @@ export const Changelog = () => {
                 <Title>Últimas alterações</Title>
             </header>
             <ul className="p-3">
-                {releases.slice(0, user.sponsor ? 4 : 2).map((release, key) => (
+                {releases.slice(0, user.dev || user.sponsor ? 4 : 2).map((release, key) => (
                     <Li key={key}>
                         <div className='relative -top-1 flex items-center gap-1'>
                             <Scope scope={release.scope} />

--- a/src/app/(pages)/dashboard/user/aside/sponsorship/index.tsx
+++ b/src/app/(pages)/dashboard/user/aside/sponsorship/index.tsx
@@ -11,7 +11,7 @@ export const Sponsorship = ({ isSponsorshipInviteAllowed, skipClose, className, 
 
     const { user } = useUser();
 
-    if (user && user.sponsor) return <></>;
+    if (user && (user.dev || user.sponsor)) return <></>;
 
     if (isSponsorshipInviteAllowed) return (
         <section

--- a/src/app/(pages)/dashboard/user/feed/item/elements/header/Message.tsx
+++ b/src/app/(pages)/dashboard/user/feed/item/elements/header/Message.tsx
@@ -22,7 +22,11 @@ export const Message = ({ user, ...rest }: MessageProps) => {
                         href={`/${user.username}`}
                         className="font-semibold hover:underline hover:text-secondary"
                     >
-                        <Icon.Sponsor user={user} size={22} className="mr-1" />{user.display_name}
+                        {user.dev
+                            ? <Icon.Dev user={user} size={22} className="mr-1.5" />
+                            : <Icon.Sponsor user={user} size={22} className="mr-1" />
+                        }
+                        {user.display_name}
                     </Link>
                 </span>
                 <span className="font-medium dark:text-lighter/75 text-darker/75"> criou uma nota</span>

--- a/src/app/(pages)/help/items.tsx
+++ b/src/app/(pages)/help/items.tsx
@@ -89,7 +89,7 @@ export const items: Items[] = [
         answer: (
             <>
                 <p>
-                    Usuários que doarem a partir de <strong>R$ 0,50</strong> ao projeto se tornam patrocinadores vitalícios,
+                    Usuários que colaborarem com o aplicativo ou doarem a partir de <strong>R$ 0,50</strong> ao projeto se tornam patrocinadores vitalícios,
                     com acesso a benefícios exclusivos.
                 </p>
                 <br />

--- a/src/app/(pages)/search/elements/results/note/elements/Creator.tsx
+++ b/src/app/(pages)/search/elements/results/note/elements/Creator.tsx
@@ -19,7 +19,10 @@ export const Creator = ({ note }: { note: LowDetailNote }) => {
             <Component.Hovercard ref={nameRef} user={note.user} />
             <Link ref={nameRef} href={`/${note.user.username}`}>
                 <h4 className="hover:underline hover:text-secondary">
-                    <Icon.Sponsor user={note.user} size={24} className="mr-1" />
+                    {note.user.dev
+                        ? <Icon.Dev user={note.user} size={24} className="mr-1" />
+                        : <Icon.Sponsor user={note.user} size={24} className="mr-1" />
+                    }
                     {note.user.display_name}
                 </h4>
             </Link>

--- a/src/app/(pages)/search/elements/results/user/elements/User.tsx
+++ b/src/app/(pages)/search/elements/results/user/elements/User.tsx
@@ -19,7 +19,10 @@ export const User = ({ user }: { user: LowDetailUser }) => {
             <Component.Hovercard ref={nameRef} user={user} />
             <Link ref={nameRef} href={`/${user.username}`}>
                 <h4 className="truncate w-[150px] hover:underline hover:text-secondary">
-                    <Icon.Sponsor user={user} size={24} className="mr-1" />
+                    {user.dev
+                        ? <Icon.Dev user={user} size={24} className="mr-1" />
+                        : <Icon.Sponsor user={user} size={24} className="mr-1" />
+                    }
                     {user.display_name}
                 </h4>
             </Link>

--- a/src/app/(pages)/settings/(pages)/account/(pages)/info/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/info/page.tsx
@@ -21,6 +21,7 @@ const Page = () => {
       <dl className="mt-6 flex flex-col gap-5">
         <Desc term="Host" desc={user.host} />
         <Desc term="Perfil" desc={user.profile_private ? "Privado" : "Público"} />
+        <Desc term="Desenvolvedor" desc={user.dev ? "Sim" : "Não"} />
         <Desc term="Patrocinador" desc={user.sponsor ? "Sim" : "Não"} />
         <Desc term="Email" desc={user.email} />
         <Desc term="Usuário" desc={`@${user.username}`} />

--- a/src/app/(pages)/settings/(pages)/sponsorship/page.tsx
+++ b/src/app/(pages)/settings/(pages)/sponsorship/page.tsx
@@ -12,7 +12,7 @@ const Page = () => {
     if (user) return (
         <section>
             <Header goBack="/settings" title="Patrocínio" />
-            {user.sponsor
+            {user.dev || user.sponsor
                 ?
                 <SponsorCard />
                 :

--- a/src/components/Hovercard.tsx
+++ b/src/components/Hovercard.tsx
@@ -146,13 +146,22 @@ export const Hovercard = ({ ref, user }: HovercardProps) => {
                 position.leftHalf ? 'after:left-4' : 'after:right-4'
             )}
         >
-            {user.sponsor && (
+            {user.dev
+                ?
                 <div aria-hidden="true" className="badge-small-top-right">
                     <div className="select-none pointer-events-none badge-content">
-                        <Icon.Sponsor user={user} useWhite />
+                        <Icon.Dev user={user} useWhite size={21} className='overflow-clip rounded-full' />
                     </div>
                 </div>
-            )}
+                : user.sponsor
+                    ?
+                    <div aria-hidden="true" className="badge-small-top-right">
+                        <div className="select-none pointer-events-none badge-content">
+                            <Icon.Sponsor user={user} useWhite />
+                        </div>
+                    </div>
+                    : null
+            }
             <header className="px-6 pt-3 flex items-center gap-3">
                 <Link href={`/${user.username}`}>
                     <Photo size={50} user={user} />

--- a/src/components/devices/desktop/navbar/dropdown/elements/Header.tsx
+++ b/src/components/devices/desktop/navbar/dropdown/elements/Header.tsx
@@ -16,7 +16,10 @@ export const Header = ({ children, user, ...rest }: HeaderProps) => {
                     {user.display_name}
                 </span>
                 <span className="max-w-[200px] flex gap-1 text-md font-faculty truncate">
-                    <Icon.Sponsor user={user} size={24} />
+                    {user.dev
+                        ? <Icon.Dev user={user} size={24} />
+                        : <Icon.Sponsor user={user} size={24} />
+                    }
                     @{user.username}
                 </span>
                 <Link

--- a/src/components/devices/desktop/navbar/dropdown/elements/Notification.tsx
+++ b/src/components/devices/desktop/navbar/dropdown/elements/Notification.tsx
@@ -59,11 +59,18 @@ export const Notification = ({ notification }: { notification: PropsType }) => {
                 <section className="flex items-center">
                     <figure className="relative px-2 border-r text-sm dark:border-r-semilight/10 border-r-semidark/10">
                         <Component.Photo user={from} size={55} />
-                        <Icon.Sponsor
-                            user={from}
-                            size={22}
-                            className="bot-mid-center drop-shadow-alpha-d-md"
-                        />
+                        {from.dev
+                            ? <Icon.Dev
+                                user={from}
+                                size={22}
+                                className="bot-mid-center drop-shadow-alpha-d-md"
+                            />
+                            : <Icon.Sponsor
+                                user={from}
+                                size={22}
+                                className="bot-mid-center drop-shadow-alpha-d-md"
+                            />
+                        }
                     </figure>
                     <section className="px-2">
                         <p className="line-clamp-6 text-sm">

--- a/src/components/devices/desktop/sidebar/elements/FollowingScope.tsx
+++ b/src/components/devices/desktop/sidebar/elements/FollowingScope.tsx
@@ -31,7 +31,7 @@ export const FollowingScope = () => {
                     key={user.username}
                     href={`/${user.username}`}
                     icon={<Component.Photo user={user} />}
-                    useBadge={user.sponsor}
+                    useBadge={user.dev ? 'dev' : user.sponsor ? 'sponsor' : 'none'}
                     text={user.username}
                 />
             ))}

--- a/src/components/devices/desktop/sidebar/elements/Link.tsx
+++ b/src/components/devices/desktop/sidebar/elements/Link.tsx
@@ -8,7 +8,7 @@ import NextLink, { LinkProps as NextLinkProps } from "next/link";
 interface LinkProps extends NextLinkProps {
     user?: User | LowDetailUser;
     icon?: React.ReactNode;
-    useBadge?: boolean;
+    useBadge?: 'dev' | 'sponsor' | 'none';
     text?: string;
     strong?: boolean;
     reverse?: boolean;
@@ -50,7 +50,9 @@ export const Link = (props: LinkProps) => {
                     ?
                     <>
                         {icon && icon}
-                        {user && useBadge && <Icon.Sponsor user={user} size={22} useWhite={active} className="-mr-2" />}
+                        {user && useBadge === 'dev' && <Icon.Dev user={user} size={22} useWhite={active} className="-mr-2" />}
+                        {user && useBadge === 'sponsor' && <Icon.Sponsor user={user} size={22} useWhite={active} className="-mr-2" />}
+                        {user && useBadge === 'none' && null}
                         {strong
                             ?
                             <strong><Span className="text-md">{text}</Span></strong>

--- a/src/components/forms/user/update/elements/Upload.tsx
+++ b/src/components/forms/user/update/elements/Upload.tsx
@@ -21,7 +21,7 @@ export const Upload = forwardRef<HTMLInputElement, UploadProps>(({ user, allowGi
                 id={name}
                 ref={ref}
                 type="file"
-                accept={user.sponsor && allowGif ? "image/png, image/jpeg, image/gif" : "image/png, image/jpeg"}
+                accept={(user.dev || user.sponsor) && allowGif ? "image/png, image/jpeg, image/gif" : "image/png, image/jpeg"}
                 className="hidden"
                 onChange={handleFileChange}
                 {...rest}

--- a/src/components/icons/Dev.tsx
+++ b/src/components/icons/Dev.tsx
@@ -1,0 +1,46 @@
+import { clsx } from 'clsx';
+import { IconCode } from '@tabler/icons-react';
+import { LowDetailUser, User } from '@/core';
+
+interface Dev extends React.ImgHTMLAttributes<HTMLImageElement> {
+    user: User | LowDetailUser;
+    size?: number;
+    useWhite?: boolean;
+}
+
+export const Dev = ({ user, size = 24, useWhite, className, ...rest }: Dev) => {
+    if (user.dev) return (
+        <figure
+            role="img"
+            aria-label="Desenvolvedor"
+            className={clsx(
+                'select-none pointer-events-none relative',
+                'flex-none inline-block align-middle',
+                className
+            )}
+            {...rest}
+        >
+            <div
+                aria-hidden="true"
+                style={{ width: `${size}px`, height: `${size}px` }}
+                className={clsx(
+                    'rounded',
+                    useWhite ? 'bg-white' : 'bg-inverted',
+                    'transition-colors'
+                )}
+            />
+            <IconCode
+                size={size * 0.8}
+                strokeWidth={3}
+                className={clsx(
+                    'center',
+                    useWhite
+                        ? 'text-primary drop-shadow-alpha-none'
+                        : 'text-white drop-shadow-alpha-d-md',
+                    'transition-colors'
+                )}
+            />
+        </figure>
+    )
+    return null;
+}

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -2,5 +2,6 @@ import { Dots } from "./Dots";
 import { Loading } from "./Loading";
 import { Logo } from "./Logo";
 import { Sponsor } from "./Sponsor";
+import { Dev } from "./Dev";
 
-export const Icon = { Logo, Sponsor, Loading, Dots };
+export const Icon = { Logo, Sponsor, Dev, Loading, Dots };

--- a/src/core/models/user/User.ts
+++ b/src/core/models/user/User.ts
@@ -10,6 +10,7 @@ export interface User {
     message: string;
     host: string;
     profile_private: boolean;
+    dev: boolean;
     sponsor: boolean;
     blocked: boolean;
     score: number;


### PR DESCRIPTION
### Sumário

Adiciona o badge de desenvolvedor (`Icon.Dev`) no frontend, exibindo-o em todos os locais onde o badge de patrocinador já aparecia. Usuários com a flag `dev` passam a ter o badge de desenvolvedor com prioridade sobre o badge de patrocinador, além de receberem os mesmos privilégios de customização.

### Alterações

- **`Icon.Dev`**: novo componente de badge com ícone `IconCode` do Tabler Icons
- **`Icon` (index)**: `Dev` exportado junto aos demais ícones
- **`User.ts`**: campo `dev` adicionado ao modelo do frontend
- **Componentes de exibição** (`Title`, `Header`, `Hovercard`, `Notification`, `FollowingScope`, `Creator`, `Message`, etc.): substituição condicional de `Icon.Sponsor` por `Icon.Dev` quando `user.dev === true`
- **`Link.tsx`**: prop `useBadge` migrada de `boolean` para `'dev' | 'sponsor' | 'none'`
- **`Upload.tsx`**: aceitação de GIF liberada também para usuários `dev`
- **`Sponsorship` e `Changelog`**: banner de patrocínio e limite de itens do changelog ocultados/expandidos para devs assim como para sponsors
- **`settings/account/info`**: campo "Desenvolvedor" adicionado à página de informações da conta
- **`help/items.tsx`**: texto atualizado para incluir colaboradores como elegíveis ao status de patrocinador

### Necessidade
Com a flag `dev` disponível na API, o frontend precisava refletir essa distinção visualmente. O badge de desenvolvedor diferencia colaboradores do projeto de patrocinadores financeiros, mantendo a hierarquia de exibição (dev tem prioridade sobre sponsor).

### Teste manual
1. Autenticar com um usuário com `dev: true` e verificar se o badge de desenvolvedor aparece no perfil, feed, busca, notificações e sidebar
2. Verificar que o banner de convite ao patrocínio **não** aparece para usuários dev
3. Verificar que o changelog exibe 4 itens para usuários dev
4. Acessar configurações → conta → informações e confirmar o campo "Desenvolvedor: Sim"
5. Tentar fazer upload de GIF como avatar com usuário dev — deve ser permitido
6. Repetir os passos acima com um usuário sem `dev` e sem `sponsor` para garantir que o comportamento padrão não foi afetado

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

## Breaking Changes
- ***Nenhuma***