### PR TITLE
feat: add password-gated sessions page with disconnect support

### DIFF
--- a/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/Disconnect.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/Disconnect.tsx
@@ -1,0 +1,35 @@
+import { IconMinus } from '@tabler/icons-react';
+import { clsx } from 'clsx';
+
+interface DisconnectProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+}
+
+const Icon = ({ icon: Icon, reverse }: { icon: React.ElementType, reverse?: boolean }) => (
+    <Icon className={clsx(
+        'origin-center will-change-transform absolute',
+        'text-light',
+        'transition-transform ease-in-out duration-[333ms]',
+        'group-disabled:rotate-0',
+        reverse
+            ? 'group-focus-visible:rotate-45 group-hover:rotate-45'
+            : 'group-focus-visible:-rotate-45 group-hover:-rotate-45'
+    )} />
+)
+
+export const Disconnect = (props: DisconnectProps) => (
+    <button
+        className={clsx(
+            'group relative w-6 h-6 rounded-full',
+            'self-center flex items-center justify-center',
+            'dark:bg-midlight/50 bg-middark/50',
+            'transition-colors duration-[333ms] ease-linear',
+            'disabled:dark:bg-primary disabled:bg-primary disabled:animate-pulse',
+            'focus-visible:dark:bg-red-500 focus-visible:bg-red-500',
+            'hover:dark:bg-red-500 hover:bg-red-500',
+        )}
+        {...props}
+    >
+        <Icon icon={IconMinus} />
+        <Icon icon={IconMinus} reverse />
+    </button>
+)

--- a/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/Item.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/Item.tsx
@@ -1,0 +1,70 @@
+import { clsx } from 'clsx';
+import { Disconnect } from './Disconnect';
+import { IconBrandAndroid, IconBrandApple, IconBrandDebian, IconBrandWindows, IconSpy } from '@tabler/icons-react';
+import { Session, toRelativeTime } from '@/core';
+import { useRouter } from 'next/navigation';
+import { useServices, useUser } from '@/data/hooks';
+import { useTransition } from 'react';
+
+interface ItemProps extends React.LiHTMLAttributes<HTMLLIElement> {
+    device: string;
+    session: Session;
+    setSessions: React.Dispatch<React.SetStateAction<Session[] | null>>;
+}
+
+export const Item = ({ device, session, setSessions, ...rest }: ItemProps) => {
+
+    const { authService } = useServices();
+
+    const { clearUser } = useUser();
+    const [isPending, startTransition] = useTransition();
+    const router = useRouter();
+
+    const handleDisconnectSession = () => startTransition(async () => {
+        await authService.disconnectSession(session.id);
+        setSessions((prev) => prev ? prev.filter(s => s.id !== session.id) : null);
+        if (device === session.device) {
+            clearUser({ skipLogout: true });
+            router.push('/');
+        }
+        return;
+    })
+
+    const osIcons: Record<string, JSX.Element> = {
+        Linux: <IconBrandDebian />,
+        macOS: <IconBrandApple />,
+        iOS: <IconBrandApple />,
+        Android: <IconBrandAndroid />,
+        Windows: <IconBrandWindows />
+    }
+
+    return (
+        <li className="min-h-12 px-2 flex gap-6" {...rest}>
+            <figure className='pointer-events-none self-center'>
+                {osIcons[session.os] ?? <IconSpy />}
+            </figure>
+            <div className='pointer-events-none flex-1 flex flex-col gap-1'>
+                <p className='capitalize font-semibold text-sm'>
+                    {session.os}, {session.deviceType}, {session.browser}
+                </p>
+                <p className='text-sm dark:text-midlight/75 text-middark/75'>
+                    {session.country}, {session.region}, {session.city}
+                </p>
+                <p className={clsx(
+                    'font-medium text-xs ',
+                    session.device === device
+                        ? 'w-fit p-1 rounded-full bg-primary text-light'
+                        : 'dark:text-semilight/50 text-semidark/50 bg-transparent'
+                )}>
+                    {session.device === device ? 'Esta sessão' : toRelativeTime(session.createdAt)}
+                </p>
+            </div>
+            <Disconnect
+                aria-label='Desconectar sessão'
+                disabled={isPending}
+                onClick={handleDisconnectSession}
+            />
+        </li>
+    )
+
+}

--- a/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/index.ts
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/sessions/elements/index.ts
@@ -1,0 +1,1 @@
+export { Item } from './Item';

--- a/src/app/(pages)/settings/(pages)/account/(pages)/sessions/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/(pages)/sessions/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Form } from '@/components/forms';
+import { Header } from '../../../Header';
+import { Item } from './elements';
+import { Session } from '@/core';
+import { useState } from 'react';
+import { useStore, useUser } from '@/data/hooks';
+
+const Page = () => {
+
+    const { token } = useUser();
+    const { store: { device } } = useStore();
+    const [sessions, setSessions] = useState<Session[] | null>(null);
+
+    if (!token) return null;
+
+    if (sessions) return (
+        <section>
+            <Header goBack="/settings/account" title="Sessões" />
+            <ul className="mt-6 flex flex-col gap-6">
+                {sessions.map((session) => (
+                    <Item
+                        key={session.id}
+                        device={device}
+                        session={session}
+                        setSessions={setSessions}
+                    />
+                ))}
+            </ul>
+        </section>
+    )
+
+    return (
+        <section>
+            <Header goBack="/settings/account" title="Acesse suas sessões" />
+            <Form.Auth.Sessions
+                onSuccess={(data) => {
+                    const current = data.find((s) => s.device === device);
+                    if (current) {
+                        const others = data.filter((s) => s.device !== device);
+                        return setSessions([current, ...others]);
+                    }
+                    return setSessions(data);
+                }}
+            />
+        </section>
+    )
+
+}
+
+export default Page;

--- a/src/app/(pages)/settings/(pages)/account/page.tsx
+++ b/src/app/(pages)/settings/(pages)/account/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Header } from "../Header";
-import { IconBellRingingFilled, IconCancel, IconEye, IconKey, IconLogout, IconMail, IconUser, IconUsers } from "@tabler/icons-react";
+import { IconBellRingingFilled, IconCancel, IconDevices2, IconEye, IconKey, IconLogout, IconMail, IconUser, IconUsers } from "@tabler/icons-react";
 import { Link } from "./Link";
 import { useScreen, useUser } from "@/data/hooks";
 
@@ -24,6 +24,7 @@ const Page = () => {
                             <Link href="/settings/account/password" icon={IconKey}>Alterar senha</Link>
                         </>
                     }
+                    <Link href="/settings/account/sessions" icon={IconDevices2}>Seus dispositivos</Link>
                     <Link href="/settings/account/delete" icon={IconCancel}>Deletar conta</Link>
                     {onMobile &&
                         <>

--- a/src/components/forms/auth/index.ts
+++ b/src/components/forms/auth/index.ts
@@ -1,5 +1,6 @@
 import { Form as SignIn } from "./signin";
 import { Form as SignUp } from "./signup";
 import { Form as Recover } from './recover';
+import { Form as Sessions } from './sessions';
 
-export const Auth = { SignIn, SignUp, Recover };
+export const Auth = { SignIn, SignUp, Recover, Sessions };

--- a/src/components/forms/auth/sessions/elements/Button.tsx
+++ b/src/components/forms/auth/sessions/elements/Button.tsx
@@ -1,0 +1,19 @@
+import { clsx } from "clsx";
+
+export const Button = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+
+    return (
+        <button
+            type="submit"
+            className={clsx(
+                'w-full px-2 py-3 rounded',
+                'text-sm',
+                'dark:bg-middark/25 bg-midlight/25',
+                'dark:drop-shadow-alpha-l-sm drop-shadow-alpha-d-sm',
+                props.disabled ? '!bg-primary text-light' : 'request-btn'
+            )}
+            {...props}
+        />
+    )
+
+}

--- a/src/components/forms/auth/sessions/elements/Error.tsx
+++ b/src/components/forms/auth/sessions/elements/Error.tsx
@@ -1,0 +1,20 @@
+import { FindSessionsFormData } from "@/core";
+import { useFormContext } from "react-hook-form";
+
+interface ErrorProps extends React.HTMLAttributes<HTMLSpanElement> {
+    name: keyof FindSessionsFormData;
+}
+
+export const Error = ({ name, ...rest }: ErrorProps) => {
+
+    const { formState: { errors } } = useFormContext();
+
+    const error = errors[name]?.message;
+
+    if (error) return (
+        <span className="font-medium text-sm text-red-600" {...rest}>
+            {error.toString()}
+        </span>
+    )
+
+}

--- a/src/components/forms/auth/sessions/elements/Field.tsx
+++ b/src/components/forms/auth/sessions/elements/Field.tsx
@@ -1,0 +1,11 @@
+import { clsx } from 'clsx';
+
+export const Field = ({ className, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={clsx(
+            "relative px-2 py-3 flex items-center",
+            className
+        )}
+        {...rest}
+    />
+)

--- a/src/components/forms/auth/sessions/elements/Input.tsx
+++ b/src/components/forms/auth/sessions/elements/Input.tsx
@@ -1,0 +1,57 @@
+import { clsx } from "clsx";
+import { FindSessionsFormData } from "@/core";
+import { Toggle } from "./Toggle";
+import { useEffect, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    name: keyof FindSessionsFormData;
+}
+
+export const Input = ({ name, ...rest }: InputProps) => {
+
+    const { register, formState: { errors } } = useFormContext();
+    const { ref, ...registerRest } = register(name);
+
+    const hasError = errors[name];
+
+    const [type, setType] = useState<"text" | "password">("password");
+
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        if (inputRef.current) {
+            const input = inputRef.current;
+            const start = input.selectionStart;
+            const end = input.selectionEnd;
+            setTimeout(() => { input.setSelectionRange(start, end) }, 0);
+        }
+    }, [type])
+
+    return (
+        <>
+            <input
+                ref={(element) => {
+                    ref(element);
+                    inputRef.current = element;
+                }}
+                id={name}
+                type={type}
+                {...registerRest}
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+                className={clsx(
+                    'peer outline-none z-10',
+                    'relative w-full mt-1 flex-1 bg-transparent',
+                    hasError && 'text-red-600 selection:bg-red-600',
+                    'text-sm'
+                )}
+                required
+                {...rest}
+            />
+            <Toggle inputType={type} setInputType={setType} />
+        </>
+    )
+
+}

--- a/src/components/forms/auth/sessions/elements/Label.tsx
+++ b/src/components/forms/auth/sessions/elements/Label.tsx
@@ -1,0 +1,25 @@
+export const Label = ({ children, ...rest }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <>
+        <label
+            className="absolute inset-0
+            rounded
+            border dark:border-middark border-midlight
+            peer-focus:border-primary
+            peer-invalid:border-red-600
+            transition-all"
+            {...rest}
+        />
+        <span
+            className="select-none pointer-events-none
+            absolute top-1 left-2
+            w-fit dark:text-midlight/75 text-middark/75 font-semibold
+            peer-focus:top-1 peer-focus:translate-y-0 peer-focus:text-primary peer-focus:text-xs
+            peer-valid:top-1 peer-valid:translate-y-0 peer-valid:text-xs
+            peer-invalid:top-1/2 peer-invalid:-translate-y-1/2 peer-invalid:text-sm peer-invalid:text-red-600
+            transition-all"
+        >
+            {children}
+        </span>
+    </>
+
+)

--- a/src/components/forms/auth/sessions/elements/Toggle.tsx
+++ b/src/components/forms/auth/sessions/elements/Toggle.tsx
@@ -1,0 +1,27 @@
+import { IconEye, IconEyeClosed } from "@tabler/icons-react";
+
+interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    inputType: "text" | "password";
+    setInputType: React.Dispatch<React.SetStateAction<"text" | "password">>
+}
+
+export const Toggle = ({ inputType, setInputType, ...rest }: ToggleProps) => {
+
+    const toggleType = () => setInputType(prev => prev === "text" ? "password" : "text");
+
+    return (
+        <button
+            tabIndex={1}
+            type="button"
+            onMouseDown={e => e.preventDefault()}
+            onClick={toggleType}
+            className="z-10 pl-1
+            dark:text-midlight/75 text-middark/75"
+            {...rest}
+        >
+            {inputType === "text" && <IconEye size={24} />}
+            {inputType === "password" && <IconEyeClosed size={24} />}
+        </button>
+    )
+
+}

--- a/src/components/forms/auth/sessions/elements/index.ts
+++ b/src/components/forms/auth/sessions/elements/index.ts
@@ -1,0 +1,7 @@
+import { Button } from "./Button";
+import { Error } from "./Error";
+import { Field } from "./Field";
+import { Input } from "./Input";
+import { Label } from "./Label";
+
+export const Element = { Field, Input, Label, Error, Button };

--- a/src/components/forms/auth/sessions/index.tsx
+++ b/src/components/forms/auth/sessions/index.tsx
@@ -1,0 +1,67 @@
+import { Element } from "./elements";
+import { FindSessionsFormData, findSessionsFormSchema, handleFieldErrors, handleInvalidTokenFieldError, Session } from "@/core";
+import { FormProvider, useForm } from "react-hook-form";
+import { useServices, useUser } from "@/data/hooks";
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
+    onSuccess?: (sessions: Session[]) => void;
+}
+
+export const Form = ({ onSuccess, ...rest }: FormProps) => {
+
+    const { authService: { findAllSessions } } = useServices();
+
+    const { token } = useUser();
+
+    const findSessionsForm = useForm<FindSessionsFormData>({
+        resolver: zodResolver(findSessionsFormSchema)
+    })
+
+    const { handleSubmit, setError } = findSessionsForm;
+
+    const [isPending, setIsPending] = useState<boolean>(false);
+    const [invalid, setInvalid] = useState<boolean>(false);
+
+    const onSubmit = async (data: FindSessionsFormData): Promise<Session[] | void> => {
+        if (token)
+            try {
+                setIsPending(true);
+                const sessions = await findAllSessions(token.access_token, data);
+                return onSuccess?.(sessions);
+            } catch (error: unknown) {
+                const err = error as { response: Response, data: any };
+                if (Array.isArray(err.data)) return handleFieldErrors(err.data, setError);
+                return handleInvalidTokenFieldError(err.data, setInvalid);
+            } finally {
+                setIsPending(false);
+            }
+    }
+
+    const { Field, Input, Label, Error, Button } = Element;
+
+    if (token) return (
+        <FormProvider {...findSessionsForm} {...rest}>
+            <form
+                onSubmit={handleSubmit(onSubmit)}
+                className="max-w-[300px] w-full mt-6"
+            >
+                <Field>
+                    <Input name="password" />
+                    <Label htmlFor="password">Senha</Label>
+                </Field>
+                <Field className='h-12'>
+                    <Error name="password" />
+                </Field>
+                <Button disabled={isPending}>Acessar</Button>
+                <p className={`${invalid ? 'opacity-100' : 'opacity-0'} text-red-600 transition-opacity`}>
+                    Token inválido.
+                </p>
+            </form>
+        </FormProvider>
+    )
+
+    return null;
+
+}

--- a/src/components/icons/Dev.tsx
+++ b/src/components/icons/Dev.tsx
@@ -16,6 +16,7 @@ export const Dev = ({ user, size = 24, useWhite, className, ...rest }: Dev) => {
             className={clsx(
                 'select-none pointer-events-none relative',
                 'flex-none inline-block align-middle',
+                'drop-shadow-alpha-d-sm',
                 className
             )}
             {...rest}
@@ -24,7 +25,7 @@ export const Dev = ({ user, size = 24, useWhite, className, ...rest }: Dev) => {
                 aria-hidden="true"
                 style={{ width: `${size}px`, height: `${size}px` }}
                 className={clsx(
-                    'rounded',
+                    'rounded-full',
                     useWhite ? 'bg-white' : 'bg-inverted',
                     'transition-colors'
                 )}
@@ -35,8 +36,8 @@ export const Dev = ({ user, size = 24, useWhite, className, ...rest }: Dev) => {
                 className={clsx(
                     'center',
                     useWhite
-                        ? 'text-primary drop-shadow-alpha-none'
-                        : 'text-white drop-shadow-alpha-d-md',
+                        ? 'text-primary'
+                        : 'text-white',
                     'transition-colors'
                 )}
             />

--- a/src/core/models/token/Session.ts
+++ b/src/core/models/token/Session.ts
@@ -1,0 +1,16 @@
+import { UUID } from 'crypto';
+
+export interface Session {
+    id: UUID;
+    device: UUID;
+    createdAt: string;
+    ip: string;
+    deviceType: 'Desktop' | 'Mobile' | 'Tablet' | 'unknown';
+    deviceBrand: string;
+    deviceModel: string;
+    os: 'Linux' | 'macOS' | 'iOS' | 'Windows' | 'Android' | 'unknown';
+    browser: string;
+    country: string;
+    region: string;
+    city: string;
+}

--- a/src/core/models/token/index.ts
+++ b/src/core/models/token/index.ts
@@ -1,3 +1,2 @@
-import { Token } from "./Token";
-
-export type { Token };
+export type { Token } from "./Token";
+export type { Session } from "./Session";

--- a/src/core/schemas/auth/Sessions.ts
+++ b/src/core/schemas/auth/Sessions.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const findSessionsFormSchema = z.object({
+    password: z.string().trim()
+})
+
+export type FindSessionsFormData = z.infer<typeof findSessionsFormSchema>;

--- a/src/core/schemas/auth/index.ts
+++ b/src/core/schemas/auth/index.ts
@@ -1,5 +1,6 @@
 import { LoginFormData, loginFormSchema } from './Login';
 import { RecoverFormData, recoverFormSchema } from './Recover';
+import { FindSessionsFormData, findSessionsFormSchema } from './Sessions';
 
-export type { LoginFormData, RecoverFormData };
-export { loginFormSchema, recoverFormSchema };
+export type { LoginFormData, RecoverFormData, FindSessionsFormData };
+export { loginFormSchema, recoverFormSchema, findSessionsFormSchema };

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -1,6 +1,7 @@
-import { LoginFormData, Token, User, Cookies, RecoverFormData } from "@/core";
+import { LoginFormData, Token, User, Cookies, RecoverFormData, Session, FindSessionsFormData } from "@/core";
 import { useAPI, useUser } from "@/data/hooks";
 import { useCallback } from "react";
+import { UUID } from 'crypto';
 
 export const AuthService = () => {
 
@@ -82,6 +83,22 @@ export const AuthService = () => {
         }
     }, [httpPost])
 
+    const findAllSessions = async (token: string, data: FindSessionsFormData): Promise<Session[]> => {
+        try {
+            return await httpPost('/auth/sessions', data, { useProgress: true, useToken: token });
+        } catch (error) {
+            return handleExpiredToken(error, (newToken) => httpPost('/auth/sessions', data, { useProgress: true, useToken: newToken }));
+        }
+    }
+
+    const disconnectSession = async (id: UUID): Promise<void> => {
+        try {
+            return await httpDelete(`/auth/session/${id}`, undefined, { useProgress: true });
+        } catch (error) {
+            throw error;
+        }
+    }
+
     return {
         loginUserByDefault,
         loginUserByGoogle,
@@ -91,7 +108,9 @@ export const AuthService = () => {
         logoutUser,
         sendSecretKeyRequest,
         sendEmailChangeRequest,
-        sendPasswordChangeRequest
+        sendPasswordChangeRequest,
+        findAllSessions,
+        disconnectSession
     }
 
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -41,6 +41,7 @@
         $rotation: 45deg;
     }
 
+    z-index: 1;
     position: absolute;
     overflow: hidden;
     width: $size;


### PR DESCRIPTION
### Sumário
Implementação da página de sessões ativas em `/settings/account/sessions`, permitindo que o usuário visualize todos os dispositivos conectados à conta e desconecte sessões individualmente. A página é protegida por senha antes de exibir as sessões. Inclui também pequenos ajustes visuais no componente `Dev` e correção de z-index em mixin SCSS.

### Alterações
- Adicionada página `/settings/account/sessions` com duas etapas: verificação de senha e listagem de sessões
- Adicionados componentes `Item` e `Disconnect` para renderização e interação com cada sessão
- Adicionado formulário `Auth.Sessions` com validação via Zod
- Adicionados `findAllSessions` e `disconnectSession` no `AuthService`
- Adicionado model `Session` e schema `findSessionsFormSchema`
- Adicionado link "Seus dispositivos" na página de configurações da conta
- Ajustes visuais no componente `Dev` (border radius e drop-shadow)
- Adicionado `z-index: 1` no mixin SCSS para correção de sobreposição

### Necessidade
Complemento visual da feature de gerenciamento de sessões implementada no backend, oferecendo ao usuário uma interface para visualizar e encerrar sessões ativas, similar ao que plataformas como Google e GitHub oferecem.

### Teste manual
1. Acessar `/settings/account`
2. Clicar em "Seus dispositivos"
3. Inserir a senha da conta e confirmar
4. Verificar se as sessões são listadas com as informações de dispositivo, OS, browser e localização
5. Verificar se a sessão atual está destacada com o badge "Esta sessão"
6. Clicar no botão de desconectar em uma sessão que não seja a atual
7. Verificar se a sessão é removida da lista
8. Clicar no botão de desconectar na sessão atual e verificar se o usuário é redirecionado para a home

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
- ***Nenhuma***