### PR TITLE
feat: add keyboard shortcuts, navigator scroll button, and ux improvements

### DIFF
--- a/src/app/(pages)/[username]/[id]/elements/index.ts
+++ b/src/app/(pages)/[username]/[id]/elements/index.ts
@@ -1,5 +1,6 @@
 import { Aside } from "./aside";
 import { Comments } from "./comments";
 import { Dialog } from "./error";
+import { Navigator } from './navigator';
 
-export const Element = { Aside, Comments, Dialog };
+export const Element = { Aside, Comments, Dialog, Navigator };

--- a/src/app/(pages)/[username]/[id]/elements/navigator/index.tsx
+++ b/src/app/(pages)/[username]/[id]/elements/navigator/index.tsx
@@ -1,0 +1,100 @@
+import { clsx } from 'clsx';
+import { IconKeyframeAlignVertical } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+export const Navigator = () => {
+
+    const [isCentered, setIsCentered] = useState(false);
+    const [top, setTop] = useState(0);
+
+    const scrollToNote = () => {
+        const noteEl = document.getElementById('note');
+        if (noteEl) return noteEl.scrollIntoView({ behavior: "smooth" });
+    }
+
+    const handleScroll = () => {
+        const scrollTop = window.scrollY;
+        const docHeight = document.documentElement.scrollHeight;
+        const winHeight = window.innerHeight;
+        if (docHeight <= winHeight) return;
+        const thumbHeight = (winHeight / docHeight) * winHeight;
+        const scrollRatio = scrollTop / (docHeight - winHeight);
+        const thumbTop = scrollRatio * (winHeight - thumbHeight);
+        setTop(thumbTop + thumbHeight / 2);
+    }
+
+    const observeNote = (onIntersect: (visible: boolean) => void) => {
+        let intersectionObserver: IntersectionObserver;
+        const createIntersection = (el: Element) => {
+            intersectionObserver = new IntersectionObserver(
+                ([entry]) => onIntersect(entry.intersectionRatio === 1),
+                { threshold: 1.0 }
+            )
+            intersectionObserver.observe(el);
+        }
+        const noteEl = document.getElementById('note');
+        if (noteEl) {
+            createIntersection(noteEl);
+            return () => intersectionObserver.disconnect();
+        }
+        const mutationObserver = new MutationObserver(() => {
+            const el = document.getElementById('note');
+            if (!el) return;
+            mutationObserver.disconnect();
+            createIntersection(el);
+        })
+        mutationObserver.observe(document.body, { childList: true, subtree: true });
+        return () => {
+            mutationObserver.disconnect();
+            intersectionObserver?.disconnect();
+        }
+    }
+
+    useEffect(() => observeNote(setIsCentered), []);
+
+    useEffect(() => {
+        scrollToNote();
+    }, [])
+
+    useEffect(() => {
+        window.addEventListener("scroll", handleScroll);
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, [])
+
+    return (
+        <div
+            aria-hidden={isCentered}
+            style={{ top: top - 16 }}
+            className={clsx(
+                'z-[10]',
+                'fixed right-2',
+                isCentered ? 'pointer-events-none' : 'pointer-events-auto',
+            )}
+        >
+            <button
+                onClick={scrollToNote}
+                className={clsx(
+                    'overflow-clip relative',
+                    'origin-center',
+                    'p-1.5 rounded-full',
+                    'flex items-center justify-center',
+                    '',
+                    'backdrop-blur-sm',
+                    'expand motion-safe:animate-expand motion-reduce:animate-none',
+                    'transition-transform duration-[333ms]',
+                    'active:scale-90',
+                    '[@media(hover:hover)]:hover:scale-90',
+                    isCentered
+                        ? 'bg-primary scale-0'
+                        : 'dark:bg-lighter/25 bg-darker/25 scale-100',
+                )}
+            >
+                <IconKeyframeAlignVertical
+                    size={22}
+                    className="dark:text-lighter text-lighter"
+                />
+            </button>
+        </div>
+    )
+
+}

--- a/src/app/(pages)/[username]/[id]/page.tsx
+++ b/src/app/(pages)/[username]/[id]/page.tsx
@@ -31,7 +31,7 @@ const Page = () => {
         if (response && response.type === 'ok') setNote(response.data);
     }, [response])
 
-    const { Aside, Comments, Dialog } = Element;
+    const { Navigator, Aside, Comments, Dialog } = Element;
 
     if (isLoading) return <Skeleton />;
 
@@ -72,6 +72,7 @@ const Page = () => {
 
         if (note) return (
             <section className="max-w-[999px] w-full m-auto pb-64">
+                <Navigator />
                 <section className="flex inlg:flex-col-reverse">
                     <Template.Portal blur="sm" triggerRef={triggerRef} childRef={childRef} closeRef={closeRef}>
                         <Form.Note.Update

--- a/src/components/forms/note/update-text/elements/Text.tsx
+++ b/src/components/forms/note/update-text/elements/Text.tsx
@@ -1,6 +1,6 @@
 import { NoteTextUpdateFormData } from "@/core";
+import { useEffect, useRef } from "react";
 import { useFormContext } from "react-hook-form";
-import { useRef } from "react";
 
 interface TextProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     setText: React.Dispatch<React.SetStateAction<string>>;
@@ -38,6 +38,14 @@ export const Text = ({ setText, value, ...rest }: TextProps) => {
         }
     }
 
+    useEffect(() => {
+        if (textareaRef.current) {
+            const len = textareaRef.current.value.length;
+            textareaRef.current.selectionStart = len;
+            textareaRef.current.selectionEnd = len;
+        }
+    }, [])
+
     return (
         <textarea
             ref={textareaRef}
@@ -46,6 +54,7 @@ export const Text = ({ setText, value, ...rest }: TextProps) => {
             spellCheck={false}
             autoCorrect="off"
             autoCapitalize="off"
+            autoFocus
             value={value}
             onChange={handleChange}
             onKeyDown={handleKeyDown}

--- a/src/components/forms/note/update-text/index.tsx
+++ b/src/components/forms/note/update-text/index.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { useNotes, useServices, useTags } from "@/data/hooks";
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
+import { useShortcuts } from './shortcuts';
 import { zodResolver } from "@hookform/resolvers/zod";
 
 interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
@@ -70,8 +71,8 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
         }
     }
 
-    const handleDeleteNote = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
-        e.stopPropagation();
+    const handleDeleteNote = async (e?: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+        if (e) e.stopPropagation();
         if (token) {
             setIsPending(true);
             await deleteNote(token.access_token, note.id)
@@ -97,32 +98,42 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
 
     const togglePreview = () => setIsPreviewing(prev => !prev);
 
-    const startEdit = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const startEdit = (e?: React.MouseEvent) => {
+        if (e) e.stopPropagation();
         setIsEditing(true);
         setIsPreviewing(false);
         return;
     }
 
-    const startSubmit = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const startSubmit = (e?: React.MouseEvent) => {
+        if (e) e.stopPropagation();
         setIsSubmiting(true);
         return;
     }
 
-    const startDelete = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const startDelete = (e?: React.MouseEvent) => {
+        if (e) e.stopPropagation();
         toggleMenu();
         setIsDeleting(true);
         return;
     }
 
-    const cancelEdit = () => {
+    const cancelEdit = (e?: React.MouseEvent) => {
+        if (e) e.stopPropagation();
         setText(initialText);
         setIsEditing(false);
         setIsPreviewing(true);
         return;
     }
+
+    useShortcuts({
+        isAuthor,
+        isEditing,
+        onStartEdit: startEdit,
+        onCancel: cancelEdit,
+        onDelete: handleDeleteNote,
+        onSave: handleSubmit(onSubmit)
+    })
 
     useEffect(() => { scrollToNote() }, []);
 

--- a/src/components/forms/note/update-text/index.tsx
+++ b/src/components/forms/note/update-text/index.tsx
@@ -3,11 +3,11 @@ import { FormProvider, useForm } from "react-hook-form";
 import { IconCheck, IconDotsVertical, IconEdit, IconTrash, IconX } from "@tabler/icons-react";
 import { Menu, MenuItem } from "@/components/menu";
 import { Note, NoteTextUpdateFormData, noteTextUpdateFormSchema, Token } from "@/core"
-import { useEffect, useState } from "react";
 import { useNotes, useServices, useTags } from "@/data/hooks";
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from "next/navigation";
 import { useShortcuts } from './shortcuts';
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
@@ -32,7 +32,7 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
         }
     })
 
-    const { handleSubmit } = updateNoteForm;
+    const { handleSubmit, setValue } = updateNoteForm;
 
     const isAuthor = author ? author === currentUser : false;
 
@@ -113,6 +113,7 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
 
     const cancelEdit = (e?: React.MouseEvent) => {
         if (e) e.stopPropagation();
+        setValue('markdown', initialText);
         setText(initialText);
         setIsEditing(false);
         setIsPreviewing(true);

--- a/src/components/forms/note/update-text/index.tsx
+++ b/src/components/forms/note/update-text/index.tsx
@@ -47,13 +47,6 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
 
     const router = useRouter();
 
-    const scrollToNote = () => {
-        const noteEl = document.getElementById("note");
-        if (noteEl) {
-            noteEl.scrollIntoView({ behavior: "smooth" });
-        }
-    }
-
     const onSubmit = async (data: NoteTextUpdateFormData): Promise<void> => {
         if (token) {
             setIsPending(true);
@@ -134,8 +127,6 @@ export const Form = ({ token, note, author, currentUser, ...rest }: FormProps) =
         onDelete: handleDeleteNote,
         onSave: handleSubmit(onSubmit)
     })
-
-    useEffect(() => { scrollToNote() }, []);
 
     const { Title, EditingTitle, ActionButton, Text, Dialog } = Element;
 

--- a/src/components/forms/note/update-text/shortcuts.ts
+++ b/src/components/forms/note/update-text/shortcuts.ts
@@ -11,11 +11,23 @@ interface ShortcutsProps {
 
 export const useShortcuts = ({ isAuthor, isEditing, onStartEdit, onCancel, onDelete, onSave }: ShortcutsProps) => {
 
+    const scrollToNote = () => {
+        const noteEl = document.getElementById('note');
+        if (noteEl) return noteEl.scrollIntoView({ behavior: "smooth" });
+    }
+
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
         if (isEditing) e.preventDefault();
     }
 
-    const handleKeyDown = (e: KeyboardEvent) => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+        if (!e.altKey) return;
+        switch (e.key.toLowerCase()) {
+            case "c": e.preventDefault(); scrollToNote(); break;
+        }
+    }
+
+    const handleAuthorKeyDown = (e: KeyboardEvent) => {
         if (!isAuthor) return;
         const isCtrl = e.ctrlKey || e.metaKey;
         if (!isCtrl) return;
@@ -32,13 +44,17 @@ export const useShortcuts = ({ isAuthor, isEditing, onStartEdit, onCancel, onDel
     }
 
     useEffect(() => {
-        window.addEventListener("keydown", handleKeyDown);
-        return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [isAuthor, isEditing, onStartEdit, onSave, onCancel, onDelete])
-
-    useEffect(() => {
         window.addEventListener("beforeunload", handleBeforeUnload);
         return () => window.removeEventListener("beforeunload", handleBeforeUnload);
     }, [isEditing])
+
+    useEffect(() => {
+        window.addEventListener("keydown", handleGlobalKeyDown);
+        window.addEventListener("keydown", handleAuthorKeyDown);
+        return () => {
+            window.removeEventListener("keydown", handleGlobalKeyDown);
+            window.removeEventListener("keydown", handleAuthorKeyDown);
+        }
+    }, [isAuthor, isEditing, onStartEdit, onSave, onCancel, onDelete])
 
 }

--- a/src/components/forms/note/update-text/shortcuts.ts
+++ b/src/components/forms/note/update-text/shortcuts.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+interface ShortcutsProps {
+    isAuthor: boolean;
+    isEditing: boolean;
+    onStartEdit: () => void;
+    onCancel: () => void;
+    onDelete: () => void;
+    onSave: () => void;
+}
+
+export const useShortcuts = ({ isAuthor, isEditing, onStartEdit, onCancel, onDelete, onSave }: ShortcutsProps) => {
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+        if (isEditing) e.preventDefault();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (!isAuthor) return;
+        const isCtrl = e.ctrlKey || e.metaKey;
+        if (!isCtrl) return;
+        switch (e.key.toLowerCase()) {
+            case "e":
+                if (!isEditing) { e.preventDefault(); onStartEdit(); } break;
+            case "q":
+                if (isEditing) { e.preventDefault(); onCancel(); } break;
+            case "d":
+                if (!isEditing) { e.preventDefault(); onDelete(); } break;
+            case "s":
+                if (isEditing) { e.preventDefault(); onSave(); } break;
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [isAuthor, isEditing, onStartEdit, onSave, onCancel, onDelete])
+
+    useEffect(() => {
+        window.addEventListener("beforeunload", handleBeforeUnload);
+        return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+    }, [isEditing])
+
+}

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -42,7 +42,7 @@ export const AuthService = () => {
     }
 
     const handleExpiredToken = async (error: any, func: (token: string) => Promise<any>) => {
-        if (error.data.message === 'Token inválido.') {
+        if (error.data && error.data.message === 'Token inválido.') {
             const { token } = await refreshUser();
             Cookies.set('rtoken', token.refresh_token, token.expires_at);
             updateToken(token);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -99,6 +99,28 @@ const config: Config = {
     },
     function ({ addUtilities, theme }: { addUtilities: any, theme: any }) {
       const newUtilities = {
+        '.expand': {
+          position: 'relative',
+          '&::after': {
+            content: '""',
+            zIndex: '-1',
+            position: 'absolute',
+            inset: '0',
+            borderRadius: '9999px',
+            transform: 'scale(0)',
+            transformOrigin: 'center',
+            transitionProperty: 'all',
+            transitionDuration: '333ms',
+          },
+          '&:hover::after': {
+            transform: 'scale(1)',
+            backgroundColor: theme('colors.primary'),
+          },
+          '&:focus-visible::after': {
+            transform: 'scale(1)',
+            backgroundColor: theme('colors.primary'),
+          },
+        },
         '.shine': {
           overflow: 'hidden',
           position: 'relative',


### PR DESCRIPTION
### Sumário
Adiciona atalhos de teclado para ações de edição de notas, um botão flutuante de navegação que rola até a nota em foco, autofocus no editor de texto, e uma correção de segurança de nulo na validação de token no serviço de autenticação.

### Alterações
- Adicionado componente `Navigator`: botão flutuante que acompanha a posição 
  do scroll e rola suavemente até o elemento da nota ao ser clicado, se 
  ocultando quando a nota já está completamente visível
- Adicionado hook `useShortcuts` com atalhos exclusivos para o autor
- Adicionado `autoFocus` no textarea da nota e posicionamento do cursor ao 
  final do texto na montagem do componente
- Lógica de `scrollToNote` movida do formulário para o `Navigator` e o hook de atalhos
- Parâmetro `e` (evento de mouse) tornado opcional em `startEdit`, `startSubmit`, 
  `startDelete` e `cancelEdit`
- `cancelEdit` agora também reseta o valor do campo via `setValue`, além do estado local
- Corrigido bug de nulo no `AuthService.handleExpiredToken`: verifica `error.data` 
  antes de acessar `error.data.message`
- Adicionada utility `.expand` no Tailwind para anel animado de hover/focus em botões arredondados

### Necessidade
Melhora o fluxo de edição por teclado para autores e oferece um ponto visual persistente para voltar à nota sem precisar rolar manualmente. A correção no auth service previne um crash em runtime quando `error.data` é undefined.

### Teste manual
1. Abrir a página de uma nota como autor
2. Rolar para longe da nota — o botão flutuante de navegação deve aparecer
3. Clicar no botão — a página deve rolar suavemente até a nota e o botão deve desaparecer
4. Pressionar `Ctrl+E` — modo de edição deve ativar com cursor ao final do texto
5. Pressionar `Ctrl+S` — alterações devem ser salvas
6. Pressionar `Ctrl+Q` — edição deve cancelar e o texto deve reverter ao original
7. Pressionar `Ctrl+D` (fora do modo de edição) — fluxo de exclusão deve ser acionado
8. Pressionar `Alt+C` — deve rolar até a nota de qualquer posição da página
9. Tentar sair da página durante edição — navegador deve exibir aviso antes de sair
10. Forçar erro de token expirado — confirmar que não há crash quando `error.data` é undefined

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
- ***Nenhuma***