### PR TITLE
fix(note): resolve editor auto focus, preview backticks and expand file upload support

### DIFF
--- a/src/components/forms/note/new/elements/FileFieldset.tsx
+++ b/src/components/forms/note/new/elements/FileFieldset.tsx
@@ -16,16 +16,98 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
     const [file, setFile] = useState<File | null>(null);
     const [dragging, setDragging] = useState<boolean>(false);
 
+    const ALLOWED_FILENAMES = new Set([
+        "Dockerfile",
+        "Makefile",
+        "CMakeLists.txt",
+        ".env",
+        ".gitignore",
+        ".gitattributes",
+        ".dockerignore",
+    ])
+
+    const ALLOWED_EXTENSIONS = new Set([
+        "txt",
+        "md",
+        "markdown",
+        "rst",
+        "csv",
+        "tsv",
+        "json",
+        "xml",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "conf",
+        "config",
+        "properties",
+        "log",
+        "rtf",
+        "sql",
+        "java",
+        "kt",
+        "groovy",
+        "js",
+        "jsx",
+        "ts",
+        "tsx",
+        "py",
+        "rb",
+        "php",
+        "go",
+        "rs",
+        "c",
+        "cpp",
+        "h",
+        "hpp",
+        "cs",
+        "swift",
+        "scala",
+        "lua",
+        "sh",
+        "bash",
+        "zsh",
+        "bat",
+        "cmd",
+        "ps1",
+        "html",
+        "htm",
+        "css",
+        "scss",
+        "less",
+        "vue",
+        "svelte",
+        "tex",
+    ])
+
+    const isAllowedTextFile = (file: File) => {
+        const fileName = file.name;
+        const lowerName = fileName.toLowerCase();
+        if (ALLOWED_FILENAMES.has(fileName) || ALLOWED_FILENAMES.has(lowerName)) return true;
+        const extension = fileName.includes(".") ? fileName.split(".").pop()?.toLowerCase() : "";
+        if (extension && ALLOWED_EXTENSIONS.has(extension)) return true;
+        return (
+            file.type.startsWith("text/") ||
+            file.type === "application/json" ||
+            file.type === "application/xml" ||
+            file.type === "application/sql"
+        )
+    }
+
     const processFile = (file: File) => {
+        if (!isAllowedTextFile(file)) return;
         const reader = new FileReader();
         reader.onload = () => {
-            setValue(name, reader.result as string, {
+            const result = reader.result;
+            if (typeof result !== "string") return;
+            setValue(name, result, {
                 shouldValidate: true,
                 shouldDirty: true,
             })
+            setFile(file);
         }
-        reader.readAsText(file, "UTF-8");
-        setFile(file);
+        return reader.readAsText(file, "UTF-8");
     }
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,7 +121,7 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
         e.stopPropagation();
         setDragging(false);
         const file = e.dataTransfer.files?.[0];
-        if (file && file.type === "text/plain") processFile(file);
+        if (file) processFile(file);
     }
 
     const handleDragEnter = (e: React.DragEvent<HTMLElement>) => {
@@ -60,11 +142,14 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
     }
 
     const onLabelKeyDown = (e: React.KeyboardEvent<HTMLLabelElement>) => {
-        if (inputRef.current && e.key === "Enter") {
+        if (!inputRef.current) return;
+        if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             inputRef.current.click();
         }
     }
+
+    const onLabelMouseDown = (e: React.MouseEvent<HTMLLabelElement>) => e.preventDefault();
 
     return (
         <fieldset
@@ -89,7 +174,7 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
                 ref={inputRef}
                 id={name}
                 type="file"
-                accept="text/plain"
+                accept=".txt,.md,.markdown,.rst,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.ini,.conf,.config,.properties,.env,.log,.rtf,.sql,.java,.kt,.groovy,.js,.jsx,.ts,.tsx,.py,.rb,.php,.go,.rs,.c,.cpp,.h,.hpp,.cs,.swift,.scala,.lua,.sh,.bash,.zsh,.bat,.cmd,.ps1,.html,.htm,.css,.scss,.less,.vue,.svelte,.tex,.gitignore,.gitattributes,.dockerignore,Dockerfile,Makefile,CMakeLists.txt,text/*,application/json,application/xml,application/sql"
                 onChange={handleFileChange}
                 className="hidden"
             />
@@ -97,22 +182,22 @@ export const FileFieldset = ({ name, children: legend, ...rest }: FieldsetProps)
                 tabIndex={0}
                 htmlFor={name}
                 onKeyDown={onLabelKeyDown}
-                onMouseDown={(e: React.MouseEvent<HTMLLabelElement>) => e.preventDefault()}
+                onMouseDown={onLabelMouseDown}
                 className={clsx(
                     'outline-none cursor-pointer',
                     'rounded p-2',
                     'font-semibold text-center dark:text-middark text-midlight',
                     'dark:hover:text-secondary/50 hover:text-primary/50',
                     'dark:focus-visible:text-secondary/50 focus-visible:text-primary/50',
-                    'transition-color duration-300',
+                    'transition-colors duration-300',
                     dragging && 'dark:text-secondary/25 text-primary/25',
                     file && 'dark:text-secondary text-primary'
                 )}
             >
                 <IconNotes size={44} className="mx-auto" />
-                {file ? file.name : ".txt"}
+                {file ? file.name : "Arquivo"}
             </label>
-        </fieldset >
+        </fieldset>
     )
 
 }

--- a/src/components/forms/note/new/index.tsx
+++ b/src/components/forms/note/new/index.tsx
@@ -60,7 +60,7 @@ export const Form = ({ token, username }: { token: string; username: string; }) 
                 <Section className="gap-3">
                     <Fieldset className="relative">
                         <Label htmlFor="title" tip="*" className="block">Título</Label>
-                        <InputText required name="title" countPosition="half" className="w-1/2 insm:w-full" />
+                        <InputText autoFocus required name="title" countPosition="half" className="w-1/2 insm:w-full" />
                         <Error field="title" />
                     </Fieldset>
                     <Fieldset className="relative">

--- a/src/components/forms/note/update-text/elements/markdown/editor/index.tsx
+++ b/src/components/forms/note/update-text/elements/markdown/editor/index.tsx
@@ -1,9 +1,9 @@
 import { clsx } from 'clsx';
 import { NoteTextUpdateFormData } from '@/core';
 import { useEditor } from './hook';
+import { useEffect, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { usePref } from '@/data/hooks';
-import { useRef } from 'react';
 
 interface MdEditorProps {
     isEditing: boolean;
@@ -24,12 +24,21 @@ export const MdEditor = ({ isEditing, isPreviewing, setText, value }: MdEditorPr
         setValue('markdown', newValue)
     }
 
-    useEditor({
+    const viewRef = useEditor({
         parentRef: editorRef,
         value,
         isDark: pref.useDarkTheme,
         onChange: handleChange,
     })
+
+    useEffect(() => {
+        if (!viewRef.current) return;
+        if (isEditing && !isPreviewing) {
+            requestAnimationFrame(() => {
+                if (viewRef.current) viewRef.current.focus();
+            })
+        }
+    }, [isEditing, isPreviewing])
 
     return (
         <div

--- a/src/components/forms/note/update-text/elements/markdown/preview/index.tsx
+++ b/src/components/forms/note/update-text/elements/markdown/preview/index.tsx
@@ -42,6 +42,7 @@ export const MdPreview = ({ isEditing, isPreviewing, markdown, ...rest }: Markdo
             // blockquote
             'dark:prose-blockquote:border-middark/50 prose-blockquote:border-midlight/50',
             // code
+            'prose-code:before:content-none prose-code:after:content-none',
             'prose-code:px-1 prose-code:py-0.5 prose-code:rounded',
             'dark:prose-code:text-light prose-code:text-dark',
             'dark:prose-code:bg-middark/50 prose-code:bg-midlight/50',


### PR DESCRIPTION
### Sumário

Correções de UX no editor e preview de notas, e expansão dos tipos de arquivo aceitos no upload.

### Alterações

- Editor (`update-text`): foco automático no CodeMirror quando `isEditing` se torna `true`
- Preview (`update-text`): remoção dos backticks gerados automaticamente pelo Tailwind Typography em `prose-code`
- Upload (`new`): expansão dos tipos de arquivo aceitos, antes limitado a `.txt`
- Upload (`new`): `setFile` movido para dentro do `onload`, evitando estado inconsistente
- Upload (`new`): adição da tecla Space como acionador do input de arquivo
- Form (`new`): `autofocus` no campo de título

### Necessidade

O editor não recebia foco ao entrar em modo de edição, exigindo clique manual do usuário. O preview exibia backticks indesejados ao redor de código inline. O upload aceitava apenas `.txt`, limitando o uso com arquivos de código e configuração.

### Teste manual

1. Entrar em modo de edição e verificar se o cursor aparece automaticamente no editor
2. Visualizar nota com código inline e confirmar ausência de backticks no preview
3. Fazer upload de arquivos `.md`, `.ts`, `.json`, `.py` e verificar se são aceitos
4. Fazer upload de `Dockerfile` e `.gitignore` e verificar se são aceitos
5. Tentar upload de `.png` ou `.pdf` e confirmar que é rejeitado
6. Abrir formulário de nova nota e verificar autofocus no campo de título

### Checklist
- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
- ***Nenhuma***